### PR TITLE
book: benchmark-eval, model-compression, and reasoning/test-time-compute chapters, plus interview companions

### DIFF
--- a/book/README.md
+++ b/book/README.md
@@ -19,7 +19,7 @@ model zoo that open live at real dimensions, not screenshots.
 - Reason about the real cost of serving an LLM: the KV cache, continuous batching, speculative decoding, quantization, cost optimization, and streaming.
 - Ground a model in knowledge: RAG, semantic search, and the embedding and re-ranking stack.
 - Compose models into products: agent orchestration and multimodal serving.
-- Know that a system works and keep it working: offline and online evaluation, safety and guardrails, and production monitoring.
+- Know that a system works and keep it working: offline and online evaluation, benchmarking a model with error bars and contamination control, safety and guardrails, and production monitoring.
 - Look ahead to the frontier: world models and world-action models that let embodied agents plan, evaluated in simulation and on real robots.
 - Connect every design choice to the architecture underneath it, traced on a real graph rather than a box diagram.
 
@@ -71,6 +71,7 @@ Ordered the way a model comes to life: build it, serve it, ground it, compose it
 | Chapter | Covers |
 |---------|--------|
 | [Evaluating LLM Systems](evaluation/) | Offline suites, LLM-as-judge, online A/B, regression gates |
+| [Benchmarking a Model](benchmark-eval/) | The benchmark pipeline end to end: harness and protocol, contamination, autorater certification, error bars, leaderboards |
 | [Safety, Moderation, and Guardrails](safety/) | Input and output filtering, jailbreak and injection defense, PII, policy routing |
 | [Production Monitoring and Observability](monitoring/) | Tracing, online eval without labels, hallucination detection, drift, regression |
 

--- a/book/benchmark-eval/01-clarifying-requirements.md
+++ b/book/benchmark-eval/01-clarifying-requirements.md
@@ -1,0 +1,85 @@
+# 1. Clarifying the requirements
+
+Before running a single benchmark, pin down what the number is *for*. Here is a
+typical exchange. Every question either removes work or changes the protocol.
+
+**Candidate:** What decision does this number drive? Picking a base model, tracking
+our own training runs, gating a release, or publishing an external claim?
+
+**Interviewer:** Two of those. We are choosing a base model for a product family,
+and we continue-pretrain and fine-tune our own variants, so we need to track whether
+each training run actually improved anything. Some of the numbers end up on a model
+card.
+
+**Candidate:** Then I need to know who the audience is for each. An internal
+selection number can be noisy and cheap; a model-card number has to be reproducible
+by someone outside the company.
+
+**Interviewer:** Correct, and assume someone will try to reproduce it.
+
+**Candidate:** Which capabilities actually matter for the product? Benchmark
+selection is where most of the error comes from, and a portfolio that does not match
+the workload measures the wrong thing precisely.
+
+**Interviewer:** Reasoning over technical documents, code generation, tool calling
+with a few internal APIs, and long inputs. Multilingual matters for two markets.
+
+**Candidate:** Are the candidates open-weight, API-only, or both? That decides
+whether I can score by log-likelihood, whether I can pin a revision, and whether I
+control the serving stack.
+
+**Interviewer:** Mixed. Two API models and one open-weight model we host.
+
+**Candidate:** Do the candidates have variable test-time compute, a reasoning or
+thinking mode with a budget I can turn up?
+
+**Interviewer:** Yes, two of them do.
+
+**Candidate:** Then quality is not a scalar; it is a curve against spend. I will
+report score against tokens and dollars, not score alone, otherwise the comparison
+silently rewards whichever model I let think longest.
+
+**Interviewer:** Fine. What does this cost us?
+
+**Candidate:** Depends on the item count, the sample count per item, and the number
+of seeds. I will size it from the smallest difference you need to detect rather than
+picking a round number.
+
+**Interviewer:** We need to be able to call a 2-point difference.
+
+**Candidate:** That constrains the design more than anything else you have said.
+
+Let us summarize the problem statement. **We are asked to design a benchmark
+evaluation pipeline that ranks a mixed set of candidate models (API and
+open-weight, some with variable test-time compute) on a capability portfolio
+matched to a product workload, tracks our own training runs against the same
+protocol, and produces numbers defensible enough to publish.** The pipeline must
+resolve differences of about 2 points, control for contamination, and report cost
+alongside quality.
+
+Two consequences fall out immediately, and stating them early accounts for most of
+the signal in this question.
+
+**Consequence 1: the score is an estimate produced by a protocol, so the protocol
+is part of the result.** The same model on the same benchmark moves by more than a
+model generation depending on prompt format, few-shot count, scoring mode, answer
+parser, decoding parameters, and output-token budget. The reported artifact is
+therefore never a bare number; it is a number, an interval, and a protocol hash
+that pins the harness commit, prompt template, model revision, decode parameters,
+and sample count. If a colleague cannot re-derive the number from that record, you
+did not measure anything, you generated one.
+
+**Consequence 2: published numbers are not comparable to yours, so you re-run every
+baseline yourself under one protocol.** A vendor's model card number was produced by
+a different harness with a different prompt and a different token budget, usually
+tuned favorably. Comparing your fine-tune against their published baseline is the
+single most common way a benchmark report gets an internal decision wrong. The rule
+is: one harness, one protocol, all candidates, including the baseline you think you
+already know.
+
+A third point is worth stating in the interview even though it is a scoping
+decision rather than a consequence: **a benchmark measures a model, not your
+product.** It filters candidates and tracks training. It does not gate a feature,
+because it does not run your prompts, your retrieval, your tools, or your users.
+The gate lives in the [evaluation chapter](../evaluation/), and a strong answer
+names that boundary before the interviewer has to.

--- a/book/benchmark-eval/02-frame-the-benchmark.md
+++ b/book/benchmark-eval/02-frame-the-benchmark.md
@@ -1,0 +1,133 @@
+# 2. Framing the benchmark
+
+## What a benchmark score actually is
+
+A benchmark score is three commitments, and naming them is the fastest way to sound
+like someone who has run evals rather than read about them.
+
+- **A construct.** The latent ability you claim to measure ("can it do competition
+  math", "can it resolve a real GitHub issue"). The construct is never observed
+  directly.
+- **An item population.** The finite sample of tasks you drew as a proxy for the
+  construct. The score is a sample statistic, so it carries sampling error, and the
+  population may not represent the construct (competition math is not engineering
+  math).
+- **A protocol.** How each item is turned into a prompt, how the model is run, and
+  how the output is turned into a number. Two protocols on the same items and the
+  same model give different scores, routinely by 10 points or more.
+
+Most benchmark arguments are really disagreements about one of the three while both
+sides talk about the number. "Is this benchmark saturated" is an item-population
+argument; "why is my MMLU 8 points below yours" is almost always a protocol
+argument; "does SWE-bench predict engineering productivity" is a construct argument.
+
+## Model-level vs system-level evaluation
+
+| Dimension | Benchmark eval (this chapter) | System eval ([evaluation chapter](../evaluation/)) |
+|---|---|---|
+| Unit under test | A model, at a pinned revision | A candidate: prompt plus model plus config plus retrieval plus tools |
+| Item source | Public or internal benchmark suites, fixed | Golden set sampled from your own traffic |
+| What it decides | Which model to build on; whether a training run improved | Whether this change ships today |
+| Comparability target | Other people's published numbers, other checkpoints | Your own production baseline |
+| Dominant risk | Contamination, protocol drift, construct mismatch | Judge miscalibration, slice regressions, stale golden set |
+| Cadence | Per checkpoint, per candidate model, per quarter | Per commit, per prompt edit |
+
+They share machinery (harness, judges, statistics) and answer different questions.
+The failure that costs the most is using one where the other belongs: gating a
+product change on MMLU, or picking a base model on a 200-row product golden set that
+only exercises one prompt.
+
+## The capability portfolio
+
+Pick benchmarks the way you pick a test suite: by what each one would catch if it
+broke, not by what is famous. As of 2026, the 2021 to 2023 multiple-choice suites
+(MMLU, HellaSwag, GSM8K, HumanEval) are saturated at the frontier, which means their
+remaining signal is mostly label noise, and the meaningful families are these.
+
+| Capability | Benchmark families | What it really measures | How it breaks |
+|---|---|---|---|
+| Knowledge and reasoning | GPQA Diamond, MMLU-Pro, Humanity's Last Exam | Recall plus multi-step inference on expert questions | Small item counts (GPQA Diamond is 198 items) make error bars wide; contamination from public mirrors |
+| Math | AIME-style competition sets, FrontierMath | Symbolic multi-step derivation under a format constraint | 30-item sets: one item is over 3 points; answer-equivalence parsing errors |
+| Code (unit-test verified) | SWE-bench Verified, LiveCodeBench, HumanEval-style pass@k | Producing a patch or function that passes tests | Weak test suites accept wrong patches; harness and container drift; contamination on old problems |
+| Agentic and tool use | tau-bench and tau2-bench, BFCL, GAIA, terminal and computer-use suites | Multi-step tool calls under a policy, with state | Inaction scored as success; partial credit hiding failures; environment flakiness |
+| Long context | RULER, HELMET, multi-round coreference retrieval sets | Retrieval and aggregation across a long input, not just a needle | Near-perfect needle-in-a-haystack scores that do not transfer to real tasks |
+| Instruction following | IFEval-style verifiable-constraint sets | Obeying explicit output constraints | Easy to overfit with formatting-focused post-training |
+| Multimodal | MMMU-Pro and successors | Cross-modal reasoning, not caption matching | Text-only shortcuts solve many items |
+| Safety and refusal | Jailbreak and policy suites, adversarial red-team sets | Behavior under adversarial pressure | Over-refusal is not measured by the same set; needs a paired benign set |
+| Economically valuable work | GDPval-style expert-task sets, METR time-horizon suites | Whether long, realistic tasks complete at all | Expensive; small n; human baselining required |
+
+Two selection rules do most of the work. **Prefer benchmarks with headroom**: a
+benchmark where every candidate scores above 90 percent cannot rank them, because
+the remaining gap is inside the label-error rate. And **always include at least one
+private internal benchmark** built from your own workload, because it is the only
+set you can prove was never trained on and the only one whose construct matches the
+product.
+
+## Saturation, headroom, and discriminative power
+
+Two models at 94.1 and 94.6 on a saturated benchmark are not 0.5 apart; they are
+tied inside label noise. A benchmark's usefulness for *ranking* depends on the
+spread of item difficulty relative to the models under test: items that every
+candidate solves and items that no candidate solves both contribute variance and no
+information. That is the same intuition item-response theory formalizes, and it is
+why frontier labs keep retiring benchmarks rather than reporting them forever.
+
+Practical test before adopting a benchmark: run two models you already know differ
+and check whether the benchmark separates them by more than its own confidence
+interval. If it cannot separate a known pair, it will not separate an unknown one.
+
+## Construct validity: does the score mean what you will use it for
+
+The score can be perfectly measured and still not support the decision.
+
+- **Multiple-choice shortcuts.** Many multiple-choice items can be answered above
+  chance without the question at all, from option patterns alone, so the format
+  measures discrimination among given options rather than the ability to produce an
+  answer. Recent work finds free-form generation plus reference matching a better
+  measure of the same construct ([Answer Matching Outperforms Multiple Choice for
+  Language Model Evaluation](https://arxiv.org/abs/2507.02856)).
+- **Item validity.** Benchmarks contain broken items. A manual re-annotation of
+  thousands of MMLU questions found a single-digit-percent error rate across
+  subjects (bad parsing, multiple correct options, no correct option, missing
+  context), released as MMLU-Redux ([Are We Done with MMLU?](https://arxiv.org/abs/2406.04127)),
+  and validity audits of adversarially filtered commonsense sets found a large
+  fraction of items with grammatical or semantic problems ([What the HellaSwag? On
+  the Validity of Common-Sense Reasoning Benchmarks](https://arxiv.org/abs/2504.07825)).
+  Label errors cap the maximum achievable score and add noise exactly where models
+  are separated.
+- **Agentic overestimation.** Weak outcome validation lets an agent "pass" without
+  solving the task. A systematic audit found SWE-bench-Verified style setups can
+  overestimate skill because test suites are too weak to reject wrong patches, and
+  that lax criteria in tau-bench can count inaction as success ([Establishing Best
+  Practices for Building Rigorous Agentic Benchmarks](https://arxiv.org/abs/2507.02825)).
+- **Population mismatch.** Competition math predicts competition math. If your
+  product is retrieval over technical documents, a math score is a proxy for a proxy.
+
+## Compare and contrast: five instruments people all call "the benchmark"
+
+| Instrument | What it gives you | What it cannot give you | Cost |
+|---|---|---|---|
+| Static public benchmark (GPQA, MMLU-Pro) | Comparability with published numbers; cheap, repeatable | Freedom from contamination; construct match to your task | Low |
+| Live or time-gated benchmark (LiveBench, LiveCodeBench) | Items released after the model's cutoff, so contamination is bounded by construction | Stable cross-time comparability; the item pool changes under you | Low to medium |
+| Private internal benchmark | Construct match plus a provable no-leak story | External comparability; a public number to cite | Medium (annotation) |
+| Human preference arena | Aggregate human taste at scale, on real prompts | Task-level correctness; immunity to style and best-of-N submission effects | Medium (traffic) |
+| Human uplift or expert trial | Whether the model changes real work outcomes | Throughput; you cannot run it per checkpoint | High |
+
+A complete answer runs a portfolio: two or three public benchmarks with headroom for
+external comparability, one live benchmark as a contamination check, and one private
+internal benchmark as the decision-maker of record.
+
+## Inputs and outputs of the pipeline
+
+**Input:** a set of candidates, where a candidate is (model identifier, revision or
+snapshot, serving stack, decode configuration, test-time-compute budget). Two budget
+settings of the same model are two candidates, not one.
+
+**Input per run:** a pinned benchmark version, including item release dates where the
+benchmark has them.
+
+**Output:** for each (candidate, benchmark, slice): a point estimate, an interval, a
+sample count, a cost in tokens and dollars, and a protocol hash. Plus a verdict on
+each pairwise comparison you were asked to make: better, worse, or not
+distinguishable at this sample size. "Not distinguishable" is a legitimate and
+frequently correct answer, and being willing to give it is a senior signal.

--- a/book/benchmark-eval/03-the-harness.md
+++ b/book/benchmark-eval/03-the-harness.md
@@ -1,0 +1,193 @@
+# 3. The harness: where the number is actually made
+
+## The pipeline, stage by stage
+
+```mermaid
+flowchart LR
+  A["item store<br/>(pinned version + metadata)"] --> B["prompt render<br/>(chat template, few-shot,<br/>answer-format instruction)"]
+  B --> C["generation<br/>(decode params, token budget,<br/>N samples, seed)"]
+  C --> D["extraction<br/>(regex / verifier / sandbox)"]
+  D --> E["scoring<br/>(exact, match, tests, rubric)"]
+  E --> F["aggregation<br/>(per slice, per seed, CI)"]
+  F --> G["report card<br/>(score + interval + cost<br/>+ protocol hash)"]
+  C -.->|"log raw outputs"| H["run store<br/>(every prompt, output, verdict)"]
+  D -.-> H
+  E -.-> H
+```
+
+The stage nobody plans for is the run store. Keeping every rendered prompt, raw
+completion, extracted answer, and per-item verdict is what makes a surprising
+result debuggable, and it is the difference between "the model got 71" and "the
+model got 71, and 4 points of the 29 it lost were truncations, not wrong answers."
+Budget the storage; it is small compared to the compute that produced it.
+
+## The knobs that move the number more than the model does
+
+This table is the heart of the topic. An interviewer asking "walk me through the
+pipeline" is checking whether you know that each of these exists.
+
+| Knob | What goes wrong | Typical swing | What to do |
+|---|---|---|---|
+| Chat template | Applying the instruct template to a base model, or none to an instruct model; wrong role tags or a missing generation prompt | Large, up to near-chance on some suites | Render with the model's own template, from the tokenizer config, and store the exact rendered string |
+| System prompt | An unstated helpful-assistant preamble that one vendor's published number used and you did not | Several points | Pin it, empty by default, and report it |
+| Few-shot count and order | 0-shot vs 5-shot changes both format and difficulty; example order changes answers | Several points | Fix k per benchmark, fix the shot pool and order by seed |
+| Scoring mode | Log-likelihood ranking over options vs generating an answer and parsing it are different measurements | Large; a model can look random under one and fine under the other | Choose per benchmark and report which; do not mix modes across candidates |
+| Length normalization | Raw log-likelihood favors short options; byte-length-normalized accuracy is a different metric | Several points | Report which normalization; keep it identical across candidates |
+| Answer-format instruction | "Put your final answer in a box" vs nothing changes parseability, not just formatting | Several points, mostly through parse failures | Standardize one instruction; measure the parse-failure rate |
+| Parser strictness | A correct answer written as "0.5" scored wrong against "1/2"; a refusal parsed as answer A | Several points, one-directional | Equivalence-aware matching, plus a manual audit of a sample of parse failures |
+| Max output tokens | A reasoning model truncated mid-derivation is scored as wrong | Very large on reasoning suites | Set a budget that clears the observed distribution; report the truncation rate |
+| Temperature and top-p | Greedy for one candidate, sampled for another; vendor-recommended settings differ per model | A few points, plus variance | One decode policy per benchmark, applied to all candidates; report it |
+| Number of samples and seeds | A single run on a 30-item benchmark is a coin flip | Double-digit swings on small reasoning sets | Multiple seeds, report mean and spread ([A Sober Look at Progress in Language Model Reasoning](https://arxiv.org/abs/2504.07086)) |
+| Serving stack and precision | Different inference engines, quantization, or batch sizes give different tokens | Small but enough to flip close calls | Pin the engine version, precision, and container digest |
+| Provider | The same open-weight model served by two providers differs in quantization, template, and throughput | Several points | Treat provider as part of the candidate identity |
+| Tool and sandbox environment | Network access, package versions, or time limits differ from the reference container | Large on agentic suites | Use the benchmark's official image, pinned by digest |
+
+The canonical write-up of this whole class of problems is
+[Lessons from the Trenches on Reproducible Evaluation of Language Models](https://arxiv.org/abs/2405.14782)
+from the maintainers of the LM Evaluation Harness, which documents cases where
+prompt format alone moves a model between near-random and competent on the same
+items. The practical implication for an interview answer: **when someone's number
+does not match yours, the prior is protocol difference, not model difference, and
+you should be able to list the six places to look in order.**
+
+## Scoring mode: log-likelihood vs generative
+
+Two ways to score a multiple-choice item, and they measure different things.
+
+**Log-likelihood ranking.** Score each option by the model's log probability of the
+option text given the question, and pick the argmax. Cheap (one forward pass per
+option, no sampling), deterministic, and immune to parse failures. Requires token
+log-probabilities, which many API models no longer expose, and it measures a
+discrimination ability the product never uses.
+
+$$\hat{y} = \arg\max_{o \in \text{options}} \frac{\log p(o \mid x)}{|o|_{\text{bytes}}}$$
+
+The byte-length normalization in the denominator is a choice, not a law: raw
+log-likelihood systematically prefers short options, normalized log-likelihood
+over-corrects on some suites, and the two are reported under different metric names
+in the same harnesses (accuracy versus normalized accuracy). Comparing your
+normalized number against someone's unnormalized number is a silent protocol bug.
+
+**Generative scoring.** Let the model produce free text, extract the answer, and
+compare against the reference. This matches how the model is used, works on
+API-only models, and is the only option for open-ended tasks. It costs sampling and
+it introduces a parser, which is now part of your measurement instrument.
+Documented inconsistencies in how multiple-choice answers get extracted from
+generated text are large enough to change model rankings
+([Right Answer, Wrong Score](https://arxiv.org/abs/2503.14996)).
+
+Rule of thumb: use generative scoring plus answer matching for anything you will
+make a claim about, keep log-likelihood scoring for cheap high-frequency training
+telemetry on base models, and never compare across the two.
+
+## Reasoning models break three assumptions
+
+Models with a variable thinking budget invalidate habits built on single-pass
+models.
+
+1. **Token budget is a capability knob.** Score against budget, not at one budget.
+   The honest artifact is a small curve: score at low, medium, and high effort, with
+   the mean output tokens at each point. A single number hides that you gave one
+   candidate 10 times the compute.
+2. **Truncation is the leading false negative.** If the budget cuts off the
+   derivation, the item is scored wrong for a reason unrelated to ability. Track
+   truncation rate as a first-class metric and treat any suite with a nonzero rate
+   as unreported until it is fixed or disclosed.
+3. **Vendor-recommended decoding differs per model.** Forcing greedy decoding on a
+   model whose recommended sampling settings are non-greedy penalizes it; letting
+   each model use its own settings makes runs non-comparable in a different way.
+   Pick one policy, state it, and check both ways on a subset when a decision is
+   close.
+
+## Determinism is not free, even at temperature zero
+
+Greedy decoding is not reproducible in a serving system, because kernels for
+normalization, matrix multiplication, and attention are not batch-invariant: the
+floating-point reduction order changes with batch composition, so the same prompt
+can produce different tokens depending on what else was in flight. Thinking Machines
+Lab documented the mechanism and shipped batch-invariant kernels that make outputs
+bit-identical across repeated runs at a throughput cost
+([Defeating Nondeterminism in LLM Inference](https://thinkingmachines.ai/blog/defeating-nondeterminism-in-llm-inference/)),
+and SGLang has published deterministic-inference support on the same idea
+([Towards Deterministic Inference in SGLang](https://www.lmsys.org/blog/2025-09-22-sglang-deterministic/)).
+
+For an eval pipeline the practical stance is: do not claim determinism you cannot
+demonstrate. Either run with batch-invariant kernels and verify by re-running a
+subset, or accept run-to-run variance and measure it, which you need anyway for the
+statistics in [section 6](06-statistics-and-leaderboards.md). The failure mode to
+avoid is reporting a single-run number as exact and then being unable to reproduce
+it in front of the person who asked.
+
+## The protocol record: what must be logged
+
+Treat this as the acceptance criterion for the pipeline. A run is reportable when
+the record contains:
+
+```text
+model:      id, revision or snapshot date, provider, serving engine + version,
+            precision / quantization, container digest
+protocol:   harness commit, benchmark name + version + item count,
+            prompt template hash, system prompt, few-shot k + shot-pool seed,
+            answer-format instruction, parser version
+decoding:   temperature, top-p, max output tokens, stop sequences,
+            samples per item, seeds, reasoning-effort setting
+results:    per-item verdict, per-slice score, aggregate score + interval,
+            parse-failure rate, truncation rate, refusal rate
+cost:       input tokens, output tokens, wall clock, dollars
+```
+
+Hash the protocol block and print the hash next to the score. Two numbers with
+different hashes are not comparable, and saying so in an interview is worth more
+than any individual metric.
+
+## Running it at scale
+
+At one benchmark and one model, the harness is a script. At a dozen benchmarks by a
+dozen candidates by several seeds, it is a service with a queue, and the design
+questions are the ordinary ones.
+
+- **Parallelism.** Items are independent, so throughput is bounded by provider rate
+  limits for API candidates and by GPU count for hosted ones. Shard by item, not by
+  benchmark, so one slow suite does not serialize the run.
+- **Caching, keyed correctly.** The cache key is the full protocol hash plus item id
+  plus sample index. Keying on prompt text alone silently serves stale results after
+  a template change, which is the worst possible bug because it looks like a null
+  result.
+- **Idempotent retries with accounting.** Provider 5xx and container flakes are
+  routine. Retry, but record how many items needed retries: a suite where 5 percent
+  of the agentic items were retried is reporting an environment number as a model
+  number.
+- **Sandboxing for code and agents.** Untrusted model output executes in the
+  benchmark's own container image, network-isolated unless the benchmark requires
+  network, with a wall-clock cap per item. Pin the image by digest; agentic scores
+  drift when base images move underneath.
+- **Cost accounting per run.** Tokens in, tokens out, dollars, and GPU-hours, stored
+  next to the score. Cost is not overhead here, it is one of the two axes any real
+  model-selection decision sits on.
+
+**Tools.** [LM Evaluation Harness](https://github.com/EleutherAI/lm-evaluation-harness)
+(EleutherAI) is the reference implementation for static suites and the source of the
+lessons paper above; [HELM](https://crfm.stanford.edu/helm/) (Stanford CRFM)
+standardizes multi-scenario reporting; [Inspect](https://inspect.aisi.org.uk/) (UK
+AI Security Institute) is built for agentic and safety evaluations with tool
+sandboxes and a solver abstraction;
+[simple-evals](https://github.com/openai/simple-evals) (OpenAI) is the minimal
+generative-scoring reference whose value is that the prompts and parsers are readable;
+SWE-bench, LiveCodeBench, and tau-bench ship their own harnesses and containers,
+which you should use rather than reimplement.
+
+## Implementation pitfalls
+
+| Symptom | Likely cause | Check |
+|---|---|---|
+| Score far below the published number | Chat template or system prompt mismatch | Print one rendered prompt and compare against the harness reference |
+| Score near chance on a suite the model should pass | Log-likelihood scoring on a chat model, or option-order formatting bug | Switch to generative scoring on 50 items and compare |
+| Reasoning suite unexpectedly weak | Output-token budget truncating derivations | Plot the output-length distribution against the cap; report truncation rate |
+| Two runs of the same candidate differ | Sampling without a fixed seed, batch-invariance nondeterminism, or provider-side model update | Re-run a 50-item subset twice; if it still moves, the stack is the variable |
+| Agentic score dropped after an infra change | Base image, package version, or network policy drift | Diff the container digest against the last good run |
+| A fine-tune improves only on one benchmark | Format overfitting to that benchmark's answer style | Run the same construct in a different format (free-form instead of multiple choice) |
+| Everything got 3 points better after a "harness cleanup" | The cleanup changed the parser | Diff the parse-failure rate before and after; re-score old outputs with the new parser |
+
+That last row is the reason to keep raw outputs: re-scoring stored completions with
+a new parser is cheap, and it separates a scoring change from a model change without
+re-running the models.

--- a/book/benchmark-eval/04-contamination-and-validity.md
+++ b/book/benchmark-eval/04-contamination-and-validity.md
@@ -1,0 +1,122 @@
+# 4. Contamination and item validity
+
+Two things can make a benchmark number meaningless while the harness runs
+flawlessly: the model has already seen the answers, or the items were never right in
+the first place. Both are measurement problems, not model problems, and both are
+routinely hand-waved in interviews with "we deduplicated the training data."
+
+## The five kinds of leakage
+
+Contamination is usually discussed as if there were one kind. There are five, and
+they need different defenses.
+
+| Kind | How it happens | Why deduplication misses it |
+|---|---|---|
+| Verbatim item leakage | The benchmark file itself is in the crawl | Only caught if you can search the training corpus, which only the trainer can do |
+| Near-duplicate leakage | Paraphrases, translations, reformatted mirrors, forum posts with the answers | Exact-match dedup passes them straight through |
+| Format leakage | The model was trained on the benchmark's answer style rather than its items | Nothing is duplicated at all; the model learned the test's shape |
+| Distillation leakage | Training on outputs of a model that was itself contaminated, or on synthetic data generated from benchmark items | The contaminated text never appears in your corpus |
+| Selection leakage | Nothing leaked into training; you chose checkpoints, hyperparameters, or prompts by looking at the test set | It is overfitting through the experimenter, and it accumulates silently |
+
+Selection leakage is the one senior candidates name and juniors miss. Running a
+benchmark 200 times while sweeping a training recipe turns the test set into a
+validation set. The fix is procedural: keep a sealed slice with a **query budget**,
+record every time it is looked at, and treat a checkpoint chosen on a sealed-slice
+comparison as having consumed one of those looks.
+
+## Detection: what you can actually run
+
+| Method | What it needs | What it tells you | Limits |
+|---|---|---|---|
+| N-gram or substring overlap between items and training corpus | Access to the training corpus | Direct evidence of verbatim and lightly-edited leakage | Only available to whoever trained the model; sensitive to n, casing, whitespace normalization |
+| Embedding near-duplicate search | Training corpus plus an embedder | Catches paraphrase and translation | Threshold is a judgment call; expensive at web scale |
+| Canary strings | The benchmark shipped a canary GUID | If the model can reproduce the canary, the file was in training | Only proves presence of the file, absence proves nothing |
+| Membership inference on token probabilities (Min-K% Prob, Min-K%++) | Token log-probabilities from the model | Statistical evidence that a specific text was in pretraining | Needs log-probs; weak on heavily-trained or paraphrased text ([Detecting Pretraining Data from Large Language Models](https://arxiv.org/abs/2310.16789), [Min-K%++](https://arxiv.org/abs/2404.02936)) |
+| Time-split comparison | Item release dates plus the model's training cutoff | The cleanest black-box signal: score on post-cutoff items versus pre-cutoff items of matched difficulty | Requires a benchmark that timestamps items, and difficulty must actually be matched |
+| Functional twins | A regenerated benchmark built to the same spec with new items | A large drop on the twin is direct evidence of overfitting to the original | Expensive; the twin must be difficulty-matched, which is the hard part |
+| Perturbation and permutation tests | Just API access | Sensitivity to option reordering or surface rewording suggests memorized surface form | Confounded with general brittleness, so it is suggestive, not conclusive |
+
+The functional-twin result is the one worth memorizing as a concrete anchor:
+rebuilding a grade-school math benchmark from scratch to the same specification and
+re-running the same models revealed systematic gaps for some model families and none
+for others, which is exactly the signature contamination produces
+([A Careful Examination of Large Language Model Performance on Grade School
+Arithmetic](https://arxiv.org/abs/2405.00332)). A survey of the move from static to
+dynamic evaluation collects the rest of the toolkit
+([Recent Advances in LLM Benchmarks against Data Contamination](https://arxiv.org/abs/2502.17521)).
+
+```python
+def min_k_percent(token_logprobs, k=0.2):     # k = fraction of least-likely tokens
+    n = max(1, int(len(token_logprobs) * k))  # how many tokens to keep
+    worst = sorted(token_logprobs)[:n]        # the least likely tokens in the text
+    return sum(worst) / n                     # higher (closer to 0) => more likely memorized
+# Compare the score for benchmark items against a held-out reference distribution of
+# same-domain text the model provably could not have seen; a shifted distribution is
+# the signal, a single number means nothing.
+```
+
+The comparison-against-a-reference-distribution point is the part people get wrong.
+A Min-K% value is not interpretable on its own; it is only interpretable against the
+distribution of the same statistic on text of the same genre that postdates the
+training cutoff.
+
+## Prevention: designs that make leakage bounded by construction
+
+- **Time-gated live benchmarks.** Draw items from sources that postdate every
+  model's cutoff and refresh continuously.
+  [LiveBench](https://arxiv.org/abs/2406.19314) builds questions from recent
+  competitions, papers, and news and rotates a fraction of the pool on a schedule;
+  [LiveCodeBench](https://arxiv.org/abs/2403.07974) tags every problem with a
+  release date so you can evaluate on a window strictly after a model's cutoff.
+  The tradeoff is that the item pool changes underneath you, so cross-time
+  comparisons need the window pinned.
+- **Private internal sets.** Built from your own workload, never published, never
+  posted to a third-party API without a data-retention review. This is the only set
+  where you can *prove* the no-leak story rather than argue it.
+- **Held-out by construction.** Procedurally generated items with a verifier
+  (templated symbolic tasks, generated code with property tests) give unlimited
+  fresh items, at the cost of a narrower construct.
+- **Canary and licence hygiene.** Ship canary GUIDs and a no-train licence with any
+  benchmark you publish, knowing both are norms rather than enforcement.
+- **Report the dates.** Every benchmark result should carry the model's training
+  cutoff and the item pool's date range. A reader can then judge contamination risk
+  without trusting your decontamination claim.
+
+## The other half: item validity
+
+Even a leak-free benchmark lies if the items are broken.
+
+- **Label errors** cap the achievable score and add noise where models are
+  separated. Re-annotation of MMLU found a single-digit-percent error rate spread
+  across parsing problems, multiple correct options, and unanswerable questions
+  ([Are We Done with MMLU?](https://arxiv.org/abs/2406.04127)); adversarially
+  filtered commonsense benchmarks show similar validity problems
+  ([What the HellaSwag?](https://arxiv.org/abs/2504.07825)). When two candidates sit
+  within the label-error band, the benchmark cannot rank them, full stop.
+- **Weak outcome validation** is the agentic analogue: the environment declares
+  success on evidence too thin to support it. The rigorous-agentic-benchmarks audit
+  found task setups whose test suites accept incorrect solutions and success criteria
+  that can count doing nothing as passing, and it packages the fixes as a checklist
+  covering task specification, outcome validation, and reporting
+  ([Establishing Best Practices for Building Rigorous Agentic Benchmarks](https://arxiv.org/abs/2507.02825)).
+- **Format artifacts.** If items can be answered above chance without the question,
+  the benchmark is partly measuring option-pattern discrimination
+  ([Answer Matching Outperforms Multiple Choice](https://arxiv.org/abs/2507.02856)).
+  The cheap audit: run the benchmark with the questions removed and report the
+  no-question baseline. Anything meaningfully above chance is a red flag you should
+  publish alongside the score.
+
+## Diagnosing a suspicious result
+
+| Symptom | First hypothesis | Test that discriminates |
+|---|---|---|
+| A model is far above its peers on one old benchmark only | Contamination on that benchmark | Score on post-cutoff items of the same construct, or on a functional twin |
+| Score collapses when options are reordered or the question is reworded | Memorized surface form, or brittleness | Perturbation set plus a no-question baseline |
+| Your fine-tune gained 5 points on the target benchmark and 0 elsewhere | Format overfitting or selection leakage | Free-form version of the same construct; check how many times the set was queried during development |
+| Everyone scores above 90 and the ordering flips between runs | Saturation plus label noise | Compute the interval; retire the benchmark for ranking purposes |
+| An agent passes tasks it visibly did not complete | Weak outcome validation | Manually audit 20 passing trajectories; that audit is not optional before publishing an agentic number |
+
+The through-line for the whole section: **a suspiciously good number is
+contamination, a broken item, or a protocol bug until proven otherwise.** Interviews
+reward the candidate who says that first and then names which of the three they
+would test.

--- a/book/benchmark-eval/05-scoring-and-autoraters.md
+++ b/book/benchmark-eval/05-scoring-and-autoraters.md
@@ -1,0 +1,169 @@
+# 5. Scoring and autoraters
+
+Scoring is where a benchmark decides what counts as right. The three questions are:
+what the metric is, who applies it, and how you know the applier is trustworthy.
+
+## Pick the metric from the task, not from habit
+
+| Task type | Default metric | Why | Failure mode to watch |
+|---|---|---|---|
+| Closed-form short answer (math, extraction, entity) | Free-form generation plus equivalence-aware answer matching | Matches how the model is used; avoids option-pattern shortcuts | Equivalence bugs ("1/2" vs "0.5", units, LaTeX); measure the parse-failure rate |
+| Multiple choice (legacy comparability only) | Accuracy, with the normalization stated | Comparable to published numbers | Saturation, option-order sensitivity, answerable-without-the-question items |
+| Code generation | Unit-test pass, reported as pass@k | Executable, unfoolable by surface plausibility | Weak tests accept wrong code; flaky tests; container drift |
+| Agent trajectories | Task success plus steps, tokens, dollars, and a reliability metric | A single success rate hides both cost and variance | Inaction counted as success; partial credit inflating scores |
+| Open-ended generation with expert criteria | Rubric grading against per-item criteria | Decomposes a fuzzy judgment into checkable claims | Rubric quality and grader agreement become the bottleneck |
+| Open-ended generation, relative | Pairwise preference by a certified judge | Relative judgments are more stable than absolute ones | Position, verbosity, and self-preference bias (see [evaluation chapter section 4](../evaluation/04-llm-as-judge.md)) |
+| Long-context tasks | Task-specific accuracy at each context length, not one aggregate | Degradation is length-dependent and non-monotonic | Needle-style retrieval saturating while real aggregation fails ([RULER](https://arxiv.org/abs/2404.06654), [HELMET](https://arxiv.org/abs/2410.02694)) |
+| Instruction following | Programmatically verifiable constraints | No judge needed, so no judge bias | Only covers constraints you can verify ([IFEval](https://arxiv.org/abs/2311.07911)) |
+
+## Answer matching: the default for closed-form tasks
+
+Give the model the question without options, let it generate, then decide whether
+the generated answer is equivalent to the reference. Equivalence is the hard part
+and it is a pipeline component with its own error rate:
+
+1. **Normalize** (strip formatting, canonicalize units, parse LaTeX).
+2. **Symbolic check** where the domain allows it (a computer algebra comparison for
+   math, running the extracted SQL for a query task).
+3. **Model-based fallback** only for what steps 1 and 2 cannot decide, using a small
+   model with the reference answer in the prompt.
+4. **Audit** a sample of both accepted and rejected answers by hand, and report the
+   matcher's own error rate.
+
+That fourth step is what separates a measurement from a guess. If the matcher
+disagrees with a human on 3 percent of items, no comparison finer than 3 points is
+supportable, and you should say so out loud when reporting.
+
+## pass@k and pass^k measure opposite things
+
+Both draw $k$ samples per task; they answer different questions, and confusing them
+is one of the most common technical mistakes in agent evaluation.
+
+**pass@k** is coverage: the probability that *at least one* of $k$ samples is
+correct. It is the right metric when something downstream can verify and select, a
+test suite, a compiler, or a human reviewer. The unbiased estimator over $n \ge k$
+drawn samples of which $c$ pass is in the [evaluation chapter](../evaluation/03-offline-eval.md).
+
+**pass^k** is reliability: the probability that *all* $k$ independent trials
+succeed, introduced with tau-bench for tool-agent-user interaction
+([tau-bench](https://arxiv.org/abs/2406.12045)). It is the right metric when the
+user gets one attempt and a failure is a failure.
+
+$$\text{pass}^k = p^k \qquad\text{so}\qquad p = 0.9 \implies \text{pass}^8 \approx 0.43$$
+
+A 90 percent success rate looks strong and is not: run the same task eight times and
+the agent gets all eight right less than half the time. The unbiased estimator from
+$n$ samples with $c$ successes mirrors the pass@k one:
+
+```python
+from math import comb
+def pass_hat_k(n, c, k):      # n trials drawn, c successes, reliability at k
+    if c < k:                 # fewer than k successes -> no k-subset is all-success
+        return 0.0
+    return comb(c, k) / comb(n, k)     # P(all k sampled trials succeeded)
+# pass_hat_k(n=10, c=9, k=8) -> 0.2  (a 90% agent is "always right" 8 times in 10 rarely)
+```
+
+Report both when the deployment allows retries and the reliability one when it does
+not. Naming this distinction unprompted is a strong signal in an agent-eval
+interview.
+
+## Rubric grading: how open-ended tasks got measurable
+
+The state of the art for expert open-ended tasks is per-item, expert-written rubric
+criteria rather than a holistic 1-to-10 score. OpenAI's HealthBench is the
+reference design: physician-written criteria attached to each conversation, each
+carrying a point value (positive for behaviors that should be rewarded, negative for
+ones that should be penalized), with a model grader deciding criterion by criterion
+whether the response meets it ([HealthBench](https://arxiv.org/abs/2505.08775)).
+
+$$s(\text{response}) = \frac{\sum_{c \in C} w_c \cdot \mathbb{1}[\text{criterion } c \text{ met}]}{\sum_{c \in C, w_c \gt 0} w_c}$$
+
+Why this beats a holistic score: each criterion is a small, checkable, nearly binary
+claim, which is the kind of judgment models and humans agree on. The rubric is also
+an artifact you can debug, version, and hand to a domain expert. The cost is
+building it, which is annotation work that does not scale by prompt engineering.
+
+The same idea appears as checklists in agent evaluation and as rubric-conditioned
+reward models in post-training; the design lesson transfers: **decompose the
+judgment until each piece is checkable, then aggregate with stated weights.**
+
+## Certifying the autorater
+
+Once a model grades your benchmark, the grader is part of the measurement
+instrument, and an uncertified instrument produces numbers of unknown bias. The
+certification steps, in order:
+
+1. **Build a meta-eval set.** A few hundred (item, response) pairs with expert
+   labels, deliberately oversampled near the decision boundary rather than on easy
+   extremes.
+2. **Measure agreement**, and report it: exact agreement, Cohen's kappa, and, for
+   pairwise judges, swap consistency. HealthBench's own design includes physician
+   meta-evaluation of the model grader for exactly this reason.
+3. **Benchmark the judge against known-hard cases.** [JudgeBench](https://arxiv.org/abs/2410.12784)
+   exists because strong general models are mediocre judges on objectively-checkable
+   pairs where the wrong answer sounds better.
+4. **Probe for gaming.** Run degenerate baselines through the grader: an empty
+   answer, a constant answer, a long padded answer, and an answer containing an
+   instruction aimed at the grader. Any of these scoring well is a blocking defect,
+   and constant-output "null models" have been shown to win non-trivial rates on
+   automatic judge benchmarks.
+5. **Pin and re-certify.** Judge model version and judge prompt are versioned
+   dependencies; re-score a frozen calibration set on a schedule to detect drift.
+
+If agreement is below bar, fix the rubric before you touch anything else. A
+sharpened criterion buys more agreement than a bigger judge model, and it is
+cheaper.
+
+## Correcting the judge statistically instead of trusting it
+
+Certification tells you the judge is biased; it does not remove the bias. The modern
+answer is to keep the cheap judge on the full set, keep a small human-labeled
+subset, and use the subset to *correct* the judge's estimate. This is
+prediction-powered inference (PPI), and it is the single most useful recent
+technique in this chapter.
+
+Let $f(X_i)$ be the judge's score on item $i$, available for all $N$ items, and
+$Y_j$ the human label on the $n \ll N$ items that were labeled by both. The
+rectified estimator is:
+
+$$\hat{\theta}_{\text{PPI}} = \underbrace{\frac{1}{N}\sum_{i=1}^{N} f(X_i)}_{\text{cheap judge estimate}} + \underbrace{\frac{1}{n}\sum_{j=1}^{n}\bigl(Y_j - f(X_j)\bigr)}_{\text{measured judge bias}}$$
+
+The first term uses every judged item; the second term is an unbiased estimate of
+the judge's systematic error. The result is unbiased regardless of how bad the judge
+is, and its variance falls as the judge gets more accurate, so a better judge buys
+tighter intervals rather than a different answer. Stratifying the human-labeled
+sample across slices tightens it further ([Stratified Prediction-Powered Inference
+for Hybrid Language Model Evaluation](https://arxiv.org/abs/2406.04291)); the same
+correction can be framed through the judge's sensitivity and specificity, with
+confidence intervals that account for uncertainty in both the test and the
+calibration set ([How to Correctly Report LLM-as-a-Judge
+Evaluations](https://arxiv.org/abs/2511.21140)).
+
+```python
+from statistics import mean
+def ppi_estimate(judge_all, judge_labeled, human_labeled):
+    # judge_all: judge scores on every item (length N)
+    # judge_labeled / human_labeled: aligned scores on the human-labeled subset (length n)
+    bias = mean(h - j for h, j in zip(human_labeled, judge_labeled))  # systematic judge error
+    return mean(judge_all) + bias                                    # rectified, unbiased
+# judge says 0.72 overall; on 200 human-labeled items it runs 0.05 high -> corrected 0.67
+```
+
+Two consequences worth saying out loud in an interview. First, this **changes the
+labeling budget question** from "can we afford to label everything" to "how many
+labels buy an acceptable interval," which is a sizing calculation rather than a
+funding fight. Second, it **removes the excuse for an uncalibrated judge**: you no
+longer need the judge to be unbiased, you need a few hundred honest labels and the
+discipline to keep collecting them as the distribution moves.
+
+## When to use which scoring approach
+
+| Reach for | When | Instead of |
+|---|---|---|
+| Executable checks (tests, symbolic equivalence, verifiable constraints) | The task admits a machine-checkable answer | A judge you would then have to certify and maintain |
+| Answer matching with a small matcher model | Short free-form answers where surface form varies | Multiple choice, which measures a narrower construct |
+| Expert rubric plus certified model grader | Open-ended expert tasks where holistic scores do not reproduce | A 1-to-10 judge score with no rubric and no meta-eval |
+| Pairwise preference by a certified judge | Ranking two candidates on open-ended quality | Absolute scores that drift across rubric versions |
+| PPI-corrected judge estimate | Any judged benchmark where the number will be reported | Raw judge means, which carry the judge's bias into the headline |
+| pass^k plus cost | User-facing agent reliability | pass@k alone, which measures coverage under retries |

--- a/book/benchmark-eval/06-statistics-and-leaderboards.md
+++ b/book/benchmark-eval/06-statistics-and-leaderboards.md
@@ -1,0 +1,171 @@
+# 6. Statistics and leaderboards
+
+Benchmarks are experiments, and until recently almost nobody analyzed them like
+experiments. The reference argument for treating them properly is
+[Adding Error Bars to Evals](https://arxiv.org/abs/2411.00640) (Anthropic, 2024),
+which imports standard experimental analysis into eval reporting and points out that
+a number of claimed advances sit inside the margin of error once the analysis is
+done correctly.
+
+## A score is an estimate, so it has a width
+
+For an accuracy $\hat p$ over $n$ independent items, the standard error and the
+usual interval are:
+
+$$\text{SE}(\hat p) = \sqrt{\frac{\hat p (1 - \hat p)}{n}} \qquad \text{CI}_{95} = \hat p \pm 1.96\,\text{SE}$$
+
+Put the item counts of real benchmarks into that and the implications are blunt.
+
+| Benchmark size | Example | 95% half-width at $\hat p = 0.5$ | What it means |
+|---|---|---|---|
+| 30 items | Competition math sets | about 18 points | A single run cannot distinguish anything; one item is over 3 points |
+| 198 items | GPQA Diamond | about 7 points | Sub-5-point gaps between models are not resolvable from one run |
+| 500 items | SWE-bench Verified | about 4.4 points | The usual headline gaps are borderline |
+| 2,000 items | Large aggregate suites | about 2.2 points | 2-point claims become discussable, not yet decided |
+
+This table alone answers the most common follow-up in the interview: *"the new model
+scores 3 points higher, is it better?"* On a 200-item benchmark, from one run, the
+honest answer is "not distinguishable yet, and here is what it would take."
+
+For small $n$, do not lean on the normal approximation. A position paper argues
+explicitly against the CLT below a few hundred datapoints
+([Don't Use the CLT in LLM Evals With Fewer Than a Few Hundred Datapoints](https://arxiv.org/abs/2503.01747));
+use a Wilson interval, an exact binomial interval, or a bootstrap instead.
+
+```python
+def wilson(p_hat, n, z=1.96):                 # better than normal approx at small n / extreme p
+    d = 1 + z * z / n
+    center = (p_hat + z * z / (2 * n)) / d
+    half = z * ((p_hat * (1 - p_hat) / n + z * z / (4 * n * n)) ** 0.5) / d
+    return center - half, center + half
+# wilson(0.5, 198) -> about (0.431, 0.569); wilson(0.9, 30) -> about (0.741, 0.965)
+```
+
+## Compare paired, always
+
+The naive comparison treats two models' scores as two independent proportions and
+adds their errors. That throws away the fact that both models answered *the same
+items*, which is the single cheapest variance reduction available.
+
+Compare per item. Let $b$ be the count of items model A got right and B got wrong,
+and $c$ the reverse (the concordant items cancel). Then:
+
+$$\hat\Delta = \frac{b - c}{n}, \qquad \text{SE}(\hat\Delta) \approx \frac{\sqrt{b + c}}{n}, \qquad z = \frac{b - c}{\sqrt{b + c}}$$
+
+The last expression is McNemar's test. A worked case on a 500-item suite: A wins 25
+items, B wins 15, so the headline gap is 2 points. Unpaired, each score carries about
+a 4.4-point interval and the comparison looks hopeless. Paired,
+$\text{SE} = \sqrt{40}/500 \approx 1.3$ points and $z = 10/\sqrt{40} \approx 1.6$:
+still not significant, but now you know exactly how far off you are and that the
+answer is more items, not more argument.
+
+Sizing follows directly. To detect a difference $\delta$ at 5 percent significance
+and 80 percent power with a discordance rate $d = (b+c)/n$:
+
+$$n \gtrsim d \left(\frac{z_{0.975} + z_{0.80}}{\delta}\right)^{2} \approx d \cdot \frac{7.85}{\delta^{2}}$$
+
+At $d = 0.1$ and $\delta = 0.02$, that is roughly 2,000 items. That number is the
+real answer to "we need to call a 2-point difference": either find a benchmark with
+thousands of items, or pool several benchmarks and accept that you are now measuring
+a composite construct.
+
+## The three other variance sources people forget
+
+**Clustering.** When items are drawn in related groups (many questions on one
+passage, many tasks in one repository, many turns in one conversation), they are not
+independent and the plain SE is too small. Compute clustered standard errors at the
+group level; the effective sample size is closer to the number of groups than the
+number of items.
+
+**Sampling variance.** With temperature above zero, each item's score is itself a
+random variable. Averaging $m$ samples per item cuts that component by $m$, which is
+often cheaper than adding items when the item pool is fixed. Report the mean over
+samples, never the best sample: taking the max over runs is best-of-N selection
+applied to yourself.
+
+**Seed and run variance.** On small reasoning benchmarks this dominates everything
+else. Re-running the same model with a different seed can swing double digits, and
+comparisons built on single runs have produced modest real effects reported as large
+ones ([A Sober Look at Progress in Language Model Reasoning](https://arxiv.org/abs/2504.07086)).
+Report mean and standard deviation over a fixed number of seeds, and state the seed
+count next to the score.
+
+## Many models times many benchmarks is a multiple-comparison problem
+
+A 12-model by 15-benchmark grid is 180 numbers and up to 990 pairwise comparisons per
+benchmark. At 5 percent significance you will find "significant" differences that are
+not there. Two defenses:
+
+- **Control the false discovery rate** (Benjamini-Hochberg) across the family of
+  comparisons you actually make, and say which family you controlled over.
+- **Pre-register the comparison.** Declare before the run which benchmarks decide the
+  question and which are descriptive. A comparison chosen after seeing the grid is a
+  hypothesis generated by the data.
+
+The same bias operates at leaderboard scale on the submission side.
+[The Leaderboard Illusion](https://arxiv.org/abs/2504.20879) documents private
+best-of-N testing before public release, where a provider evaluates many variants and
+publishes only the best, which violates the assumptions of the ranking model and
+inflates the published score; the arena operators dispute the magnitude
+([LMArena's response](https://lmarena.ai/blog/our-response/)). Whatever the size of
+the effect, the lesson for your own reporting is the same: **the number of variants
+you tried before publishing one is part of the result.**
+
+## Aggregating into an index without lying
+
+Composite indices are more robust than any single benchmark, because gaming one eval
+barely moves the aggregate. They are also easy to build badly.
+
+- **Normalize before averaging.** Benchmarks have different floors (chance level is
+  25 percent on a 4-option set, 0 percent on free-form) and different ceilings.
+  Average raw percentages and you weight by scale, not importance.
+- **State the weights.** An unweighted mean is a weighting, chosen by which
+  benchmarks happened to be included.
+- **Bootstrap the aggregate.** Resample items within each benchmark, recompute the
+  index, and report the interval on the index and, more importantly, on the *rank*.
+  Rank stability is what readers actually consume, and it is usually much weaker than
+  the point estimates suggest.
+- **Drop saturated components.** A benchmark where every candidate is above 90
+  contributes noise and a false sense of coverage.
+
+For preference-based ranking, the arena family fits a Bradley-Terry model over
+pairwise votes, where the probability that model $i$ beats model $j$ is
+$\sigma(\beta_i - \beta_j)$ with $\beta$ the fitted strengths. Two practical notes:
+the fitted strengths come with confidence intervals, and overlapping intervals mean
+a tie no matter what the sorted table looks like; and preference votes partly track
+style, which is why arenas now publish style-controlled variants that regress out
+response length and formatting. A model that wins on style control and loses without
+it (or the reverse) is telling you something a single rank cannot.
+
+## Report cost with quality or the comparison is not a comparison
+
+Test-time compute makes quality a curve. A candidate that spends five times the
+output tokens should not be compared against one that does not, at least not without
+saying so. The reportable unit is a point on a frontier:
+
+| Candidate | Score | 95% CI | Output tokens per item | Cost per 1k items | Latency p50 |
+|---|---|---|---|---|---|
+| Model A, low effort | 61.2 | +/- 3.4 | 480 | \$4.10 | 3.1 s |
+| Model A, high effort | 68.9 | +/- 3.2 | 4,900 | \$38.60 | 27 s |
+| Model B, default | 66.4 | +/- 3.3 | 1,100 | \$11.20 | 7.4 s |
+
+Read as a table of scores, A-high wins. Read as a frontier, B is the better default
+and A-high is a fallback for hard items, which is the decision the product actually
+needs. METR's time-horizon methodology takes the same idea further by expressing
+capability in units of human task length rather than percentage points, fitting the
+task duration at which a model succeeds half the time
+([Measuring AI Ability to Complete Long Software Tasks](https://arxiv.org/abs/2503.14499)).
+
+## The decision rule
+
+| Situation | Verdict to report |
+|---|---|
+| Paired CI on the difference excludes 0 on the pre-registered benchmarks | Better, with the interval |
+| Paired CI includes 0 | Not distinguishable at this sample size; state the size needed |
+| Wins on some benchmarks, loses on others, all inside intervals | Tie; decide on cost, latency, or the internal benchmark |
+| Wins the aggregate but loses the internal benchmark | Prefer the internal benchmark and say why: it matches the construct and cannot be contaminated |
+| Wins only after being given more test-time compute | Report as a cost-matched loss and an effort-matched win |
+
+Being comfortable saying "not distinguishable" is the most senior-sounding thing in
+this chapter, and it is almost always the statistically correct verdict for the small
+public benchmarks people quote most often.

--- a/book/benchmark-eval/07-how-teams-do-it-in-production.md
+++ b/book/benchmark-eval/07-how-teams-do-it-in-production.md
@@ -1,0 +1,56 @@
+# 7. How teams do it in production
+
+Everyone who runs benchmarks seriously converges on the same skeleton: pinned items,
+a standardized harness, raw outputs kept, and a report that carries the protocol.
+What differs is **what they standardize** (the prompt, the environment, or the
+statistics) and **what they treat as the threat** (contamination, gaming, or
+irreproducibility). Reading the table by those two columns is the fastest way to
+place any eval stack you meet.
+
+## Where the real designs diverge
+
+| System | What it standardizes | Scoring approach | Contamination stance | Statistics | When it wins | Watch out |
+|---|---|---|---|---|---|---|
+| LM Evaluation Harness (EleutherAI) | Prompt rendering, task definitions, versioned task configs | Log-likelihood and generative, per task | Documents the risk; leaves policy to the user | Per-task stderr reported | Reproducible static-suite comparisons across many models | Defaults differ from vendor protocols, so numbers still need a protocol hash |
+| HELM (Stanford CRFM) | Multi-scenario, multi-metric reporting matrix | Task metrics plus efficiency and calibration alongside accuracy | Public scenario set, so contamination grows with age | Reports across scenarios rather than one index | Holistic comparison where one number would mislead | Heavy to run; scenario coverage ages |
+| Inspect (UK AI Security Institute) | The agent loop and the tool sandbox | Solvers plus scorers, including model-graded scorers | Designed for private and safety evals | Per-sample logs for audit | Agentic and safety evaluations that need a controlled environment | Requires environment engineering, not just prompts |
+| simple-evals (OpenAI) | Chat-formatted generative scoring with readable prompts and parsers | Generative plus answer matching | Prefers newer sets over saturated ones | Minimal by design | Making a protocol legible so others can replicate it | Deliberately minimal; not a full platform |
+| HealthBench (OpenAI) | Per-item expert rubric criteria with weights | Model grader scoring criterion by criterion, meta-evaluated against physicians | Purpose-built set, released with the rubric | Meta-eval of grader against expert judgment | Expert open-ended domains where holistic scores do not reproduce | Rubric construction is the cost; graders need re-certification |
+| Anthropic eval-statistics practice | The analysis, not the prompt | Any | Orthogonal | Clustered SE, paired differences, resampling, power | Deciding whether a reported gap is real | Correct analysis often turns headline gaps into ties, which is unpopular |
+| LMArena | Human pairwise preference at traffic scale | Bradley-Terry over votes, plus style-controlled variants | Fresh prompts arrive continuously | Ranking intervals, style control | Aggregate human taste on open-ended chat | Best-of-N private submissions and style effects, disputed in size |
+| Artificial Analysis | A composite index plus price and speed per provider | Aggregates many public evals | Refreshes components as they saturate | Composite over many evals | Cross-provider serving and quality tradeoffs in one view | An index hides which component moved |
+| METR | Task suites with human baselines, measured in task length | Task success as a function of human completion time | Private task suite | Logistic fit for the 50 percent time horizon | Expressing capability in units a business understands | Expensive human baselining; small task counts |
+| LiveBench | Monthly refreshed items from recent sources | Objective ground truth, no judge in the loop | Contamination bounded by construction | Refresh policy stated | A contamination check on any static-suite result | The pool changes, so cross-time comparisons need a pinned window |
+| LiveCodeBench | Problems tagged with release dates | Unit tests, plus self-repair and execution variants | Evaluate strictly after a model's cutoff | Windowed comparisons | Code capability without the old-problem contamination question | Window choice changes the number; state it |
+| SWE-bench and SWE-bench Verified | The repository environment and the test command | Unit-test pass on a real repo state | Old issues are public and aged | Per-instance logs | Realistic software-engineering signal | Weak test suites can accept wrong patches; container drift |
+
+## The dividing line
+
+Two axes explain nearly every difference above. **What you standardize** determines
+what your numbers are comparable to: standardize the prompt and you can compare
+against other harness users; standardize the environment and you can compare agents;
+standardize the analysis and you can compare claims. **What you treat as the threat**
+determines your design: if it is contamination you build time-gating, if it is gaming
+you build private held-out sets and audit the submission process, and if it is
+irreproducibility you build protocol hashes and deterministic serving.
+
+A complete interview answer picks a point on both axes and justifies it from the
+decision the number drives. Picking a base model for a product tolerates aged public
+suites plus one internal set. Publishing a model-card number does not.
+
+## First-party sources
+
+- **EleutherAI** [Lessons from the Trenches on Reproducible Evaluation of Language Models](https://arxiv.org/abs/2405.14782) and the [LM Evaluation Harness](https://github.com/EleutherAI/lm-evaluation-harness): why prompt format and scoring mode change results, and a versioned task system that pins both.
+- **Stanford CRFM** [HELM](https://crfm.stanford.edu/helm/): holistic multi-scenario, multi-metric evaluation instead of a single headline number.
+- **UK AI Security Institute** [Inspect](https://inspect.aisi.org.uk/): an evaluation framework built around solvers, scorers, and sandboxed tool environments for agentic and safety evals.
+- **OpenAI** [simple-evals](https://github.com/openai/simple-evals): a deliberately small generative-scoring harness whose prompts and parsers are meant to be read.
+- **OpenAI** [HealthBench](https://openai.com/index/healthbench/) and the [paper](https://arxiv.org/abs/2505.08775): per-conversation physician-written rubric criteria, model-graded, with expert meta-evaluation of the grader.
+- **Anthropic** [Adding Error Bars to Evals](https://arxiv.org/abs/2411.00640): clustered standard errors, paired differences, resampling, and power analysis applied to eval reporting.
+- **LMArena** [response to The Leaderboard Illusion](https://lmarena.ai/blog/our-response/), alongside the critique itself, [The Leaderboard Illusion](https://arxiv.org/abs/2504.20879): what private best-of-N submission does to a preference ranking, and how much it matters.
+- **METR** [Measuring AI Ability to Complete Long Software Tasks](https://metr.org/blog/2025-03-19-measuring-ai-ability-to-complete-long-tasks/) and the [paper](https://arxiv.org/abs/2503.14499): the 50 percent time-horizon methodology with human baselines.
+- **LiveBench** [livebench.ai](https://livebench.ai/) and the [paper](https://arxiv.org/abs/2406.19314): monthly-refreshed items with objective ground truth and no judge in the loop.
+- **LiveCodeBench** [livecodebench.github.io](https://livecodebench.github.io/) and the [paper](https://arxiv.org/abs/2403.07974): release-date-tagged problems evaluated in windows after a model's cutoff.
+- **Princeton NLP** [SWE-bench](https://arxiv.org/abs/2310.06770): real GitHub issues resolved against the repository's own tests.
+- **UIUC and collaborators** [Establishing Best Practices for Building Rigorous Agentic Benchmarks](https://arxiv.org/abs/2507.02825): the checklist for task specification and outcome validation, with measured overestimation in widely used agentic benchmarks.
+- **Thinking Machines Lab** [Defeating Nondeterminism in LLM Inference](https://thinkingmachines.ai/blog/defeating-nondeterminism-in-llm-inference/): why identical requests differ, and batch-invariant kernels that fix it.
+- **Epoch AI** [benchmarking hub](https://epoch.ai/benchmarks): independently re-run benchmark results with the protocol documented.

--- a/book/benchmark-eval/08-interview-qa.md
+++ b/book/benchmark-eval/08-interview-qa.md
@@ -1,0 +1,323 @@
+# 8. Interview Q&A
+
+The questions actually asked about benchmarking a model, grouped by how they are
+used. The traps at the bottom are where this interview is usually lost, because each
+one has an answer that sounds right and is wrong.
+
+## Commonly asked
+
+**Q: Walk me through the whole pipeline. How do you evaluate a model on benchmarks?**
+
+A: Eight stages, and the interesting content is in the middle three.
+
+1. **Decide what the number is for.** Model selection, training telemetry, a release
+   gate, or an external claim. That decides the required rigor and the audience.
+2. **Select a portfolio, not a benchmark.** Capabilities matched to the workload,
+   each with headroom, plus at least one private internal set that cannot be
+   contaminated and does match the construct.
+3. **Pin the items.** Benchmark version, item count, release dates, licence.
+4. **Fix the protocol.** Chat template, system prompt, few-shot count and order,
+   answer-format instruction, scoring mode, decode parameters, output-token budget,
+   samples per item, seeds. This is where most of the variance between published
+   numbers comes from, so it is written down and hashed, not assumed.
+5. **Run it, keeping everything.** Sharded by item, cached on the full protocol hash,
+   sandboxed for code and agents, with tokens and dollars accounted per run, and
+   every rendered prompt and raw completion stored.
+6. **Score.** Executable checks where the task allows, answer matching for short
+   free-form, rubric grading with a certified grader for open-ended, unit tests for
+   code, task success plus cost plus reliability for agents. Track parse-failure,
+   truncation, and refusal rates as first-class outputs.
+7. **Analyze like an experiment.** Paired per-item comparisons, intervals, seed
+   variance, clustered errors where items are grouped, multiple-comparison control
+   over the grid you actually ran.
+8. **Report a card, not a number.** Score, interval, sample and seed counts, cost per
+   item, protocol hash, contamination evidence, and a verdict per comparison that is
+   allowed to be "not distinguishable."
+
+Then say the thing that frames the whole answer: the pipeline's job is not to
+produce a high number, it is to produce a number that survives someone trying to
+reproduce it.
+
+**Q: How do you choose which benchmarks to run?**
+
+A: Work backwards from the decision. List the capabilities the product depends on
+(say retrieval-heavy reasoning, code edits, tool calling, long inputs, two
+languages), pick one benchmark per capability that still has headroom, and drop
+anything where all candidates already score above about 90 since the remaining gap
+is inside label noise. Add one live or time-gated benchmark as a contamination
+check, and one private internal set that is the decision-maker of record. Before
+adopting a benchmark, validate it can separate two models you already know differ by
+more than its own confidence interval; if it cannot, it will not separate the ones
+you are actually comparing.
+
+**Q: Your number does not match the vendor's published number. What happened?**
+
+A: The prior is protocol, not model. I check in this order because that is roughly
+the order of magnitude of the effects: chat template and system prompt, few-shot
+count and order, scoring mode (log-likelihood ranking versus generative plus
+parser), output-token budget and truncation rate, decode parameters and sample
+count, then benchmark version and item subset. The maintainers of the LM Evaluation
+Harness documented cases where prompt formatting alone moves a model between near
+random and competent on the same items, which is larger than any model-generation
+gap I would be arguing about. The resolution is not to reconcile the numbers but to
+re-run every candidate, including the baseline, under one protocol I control.
+
+**Q: How do you know a 3-point difference is real?**
+
+A: Compute it paired. Both models answered the same items, so the concordant items
+cancel and only the discordant ones carry information: with $b$ items A wins and $c$
+items B wins, the difference is $(b-c)/n$ with standard error about
+$\sqrt{b+c}/n$. On a 200-item benchmark the unpaired interval on each score is
+around 7 points, so a 3-point gap from one run is not resolvable, but paired it may
+be. If the interval still includes zero, the answer is "not distinguishable at this
+sample size," plus the item count that would settle it, which at a 2-point target
+and typical discordance is on the order of a couple of thousand items. Report seed
+variance too: on small reasoning benchmarks, run-to-run swings exceed the effect
+people are claiming.
+
+**Q: How do you evaluate a model with a variable thinking budget?**
+
+A: Treat the budget as part of the candidate, not part of the model. The same model
+at low and high effort are two candidates, and quality is a curve against spend, so
+I report score against mean output tokens and cost at two or three effort levels.
+Two operational points: set the output-token cap from the observed length
+distribution and report the truncation rate, because a truncated derivation is
+scored as a wrong answer for a reason unrelated to ability; and either apply one
+decode policy to every candidate or use each vendor's recommended settings and say
+which, since mixing the two silently advantages whichever model got its preferred
+configuration.
+
+**Q: How do you handle contamination?**
+
+A: Prevention where I control training, detection where I do not. On the training
+side, decontamination is a data-pipeline job: n-gram and near-duplicate removal of
+benchmark items and their paraphrases, with the caveat that it cannot catch
+distillation from a contaminated teacher. On the evaluation side, since I usually
+cannot see someone else's corpus, I rely on black-box evidence: score post-cutoff
+items against difficulty-matched pre-cutoff items, run a time-gated benchmark like
+LiveBench or a release-date window in LiveCodeBench, and where I can get token
+probabilities use membership-inference statistics such as Min-K% against a reference
+distribution of text the model could not have seen. The strongest single check is a
+functional twin, a benchmark rebuilt to the same specification with new items; a
+large drop on the twin is the contamination signature. And I keep a private internal
+set, which is the only one where the no-leak story is provable rather than
+argued.
+
+**Q: How is evaluating an agent different?**
+
+A: Three differences. The environment becomes part of the measurement, so the
+container is pinned by digest, the network policy is stated, and retries are counted
+(a suite where 5 percent of items needed a retry is reporting infrastructure, not
+capability). Outcome validation has to be strong enough to reject a wrong solution;
+audits of widely used agentic benchmarks found test suites weak enough to accept
+incorrect patches and success criteria that can score inaction as success, so I
+manually audit a sample of passing trajectories before publishing anything. And the
+metric changes: a single success rate hides both cost and variance, so I report task
+success plus steps and dollars, and reliability as pass^k, the probability that all
+$k$ independent attempts succeed, rather than pass@k, which is coverage under
+retries.
+
+## Tricky (the follow-ups that separate people)
+
+**Q: Our fine-tune gained 6 points on the target benchmark and users say it got
+worse. What happened?**
+
+A: Most likely one of three, and they are distinguishable. **Format overfitting**:
+the fine-tune learned the benchmark's answer shape rather than the capability, which
+shows up as a gain that vanishes when the same construct is asked free-form instead
+of multiple choice. **Selection leakage**: the benchmark was used to choose the
+checkpoint and the hyperparameters, so the reported number is a maximum over many
+looks rather than an unbiased estimate; the tell is how many times the set was
+queried during development. **Narrow gain with broad regression**: the benchmark
+moved and everything else quietly dropped, which is why a regression portfolio
+including instruction following, refusal behavior, and the internal set runs on every
+checkpoint. The confirming experiment is cheap: rebuild the same construct in a
+different format, evaluate on a held-out slice that was never queried, and diff the
+full portfolio rather than the headline.
+
+**Deeper:** These three have different fixes and only one of them is a model
+problem. Format overfitting is fixed in the data mix, selection leakage is fixed by
+process (a sealed slice with a query budget), and a broad regression is fixed by
+training. Diagnosing which you have before proposing a fix is most of the value.
+
+**Q: We are grading an open-ended benchmark with a model. How do you make that
+number trustworthy?**
+
+A: Certify, then correct, and do not skip the second step. Certification is a
+meta-eval set of a few hundred expert-labeled pairs oversampled near the decision
+boundary, reporting agreement and swap consistency, plus adversarial probes: empty
+answers, constant answers, padded answers, and answers containing an instruction
+aimed at the grader. Correction is statistical: keep the cheap grader on all $N$
+items, keep human labels on a small $n$, and use prediction-powered inference, which
+adds the measured judge bias back to the judge's mean and is unbiased no matter how
+poor the judge is. That reframes the budget question from "can we label everything"
+to "how many labels buy an acceptable interval." Also report the grader's own error
+rate, because no comparison finer than that rate is supportable.
+
+**Deeper:** The reason certification alone is not enough: agreement statistics tell
+you the judge is wrong at some rate, but a gate needs an unbiased estimate of the
+quantity, not a characterization of the instrument. PPI converts the instrument's
+measured error into a correction term, which is why a mediocre judge plus 200 honest
+labels can beat a great judge with none.
+
+**Q: Same model, same prompt, temperature zero, and two runs disagree. Why?**
+
+A: Greedy decoding is deterministic in principle and not in a serving system.
+Kernels for normalization, matmul, and attention are not batch-invariant, so the
+floating-point reduction order depends on what else was batched with your request,
+and a single token flip early in a derivation changes everything after it. Other
+candidates for the same symptom: the provider silently updated the model behind an
+alias, a different serving engine or quantization, or a nondeterministic parser or
+sandbox. The remedies in order: pin revisions and engine versions, use
+batch-invariant kernels if reproducibility is a requirement and accept the
+throughput cost, or accept run variance and measure it, which you need for the error
+bars anyway. What you must not do is report a single-run number as exact.
+
+**Q: How would you build an internal benchmark that is still useful in two years?**
+
+A: Design for refresh and for a budget of looks. Source items continuously from
+production traffic and from experts, timestamp every item, and retire items that
+every candidate solves (they cost compute and carry no information). Split into a
+public-internal portion people iterate against and a sealed portion with a query
+budget, where every evaluation against the sealed set is logged and a checkpoint
+chosen on it consumes a look. Store items with per-item metadata for slicing
+(language, length, domain, difficulty), keep a rubric rather than a single reference
+answer for open-ended items so the grading criteria are debuggable, and re-certify
+the grader on a schedule. The failure mode this design targets is not going stale in
+content, it is going stale in difficulty, which is why difficulty-targeted item
+addition matters more than volume.
+
+**Q: The eval grid is 12 candidates by 15 benchmarks by 5 seeds. Make it affordable.**
+
+A: Four levers, roughly in order of savings. **Stage it**: a cheap smoke subset (a
+few hundred items across benchmarks) ranks candidates coarsely, and only the
+survivors get the full grid, which usually cuts the grid by half or more. **Cache on
+the protocol hash** so re-runs after a scoring or parser change re-score stored
+outputs instead of regenerating them, which is the single biggest saver during
+iteration. **Right-size the sample counts per benchmark from the statistics**: small
+benchmarks need many seeds and large ones need few, so a flat 5 seeds everywhere
+overspends on the large suites and underspends on the small ones. **Shard by item
+across providers and GPUs** to convert cost pressure into wall-clock pressure. And
+report what you cut: if the safety suite ran at 200 of 2,000 items, that belongs in
+the report, because a silently truncated suite reads as full coverage.
+
+**Q: Which do you trust when the public benchmarks and the internal benchmark
+disagree?**
+
+A: The internal one, and I can say why in one sentence: it matches the construct we
+care about and it is the only set I can prove was not trained on. The public
+disagreement is still information, though. If the model wins publicly and loses
+internally, the likely causes are distribution mismatch (our prompts, our documents,
+our tools) or contamination inflating the public number. If it loses publicly and
+wins internally, the model may be specialized in a way that suits us, which is a
+reason to check whether our internal set is too narrow. Either way the internal set
+decides the deployment and the public numbers stay as the external comparability
+story.
+
+## Commonly answered wrong (the traps)
+
+**Q: We removed exact duplicates of the benchmark from the training data, so
+contamination is handled. True?**
+
+A: No. Exact-match deduplication catches the easiest case and misses the four that
+matter: near-duplicates and paraphrases, translations and reformatted mirrors,
+format leakage where the model learned the test's answer style without seeing its
+items, and distillation from a teacher that was itself contaminated. It also does
+nothing about selection leakage, where nothing leaked into training but the test set
+was consulted hundreds of times while choosing checkpoints. A defensible answer
+pairs a decontamination claim with its parameters (n-gram size, normalization,
+near-duplicate threshold) and, more importantly, with black-box evidence:
+performance on post-cutoff items, on a functional twin, or on a private set.
+
+**Deeper:** The asymmetry is what makes this trap dangerous. Decontamination
+evidence is a claim about a corpus only the trainer can inspect, while the
+time-split and functional-twin tests are runnable by anyone. In an interview, the
+person who reaches for the runnable test is demonstrating that they know the claim
+is unverifiable by the reader.
+
+**Q: MMLU and HumanEval are the standard, so report those. Right?**
+
+A: They were the standard, and at the frontier they are saturated, which means the
+gap between candidates is inside the benchmark's own label-error and sampling noise.
+Multiple-choice formats carry a second problem: a nontrivial fraction of items can
+be answered above chance without seeing the question at all, so the format partly
+measures option discrimination rather than the ability to produce an answer. Re-run
+them if you need comparability with published numbers, but the decision should rest
+on benchmarks with headroom, a free-form scored version of the same construct, and
+your internal set. And publish the no-question baseline for any multiple-choice set
+you rely on.
+
+**Q: The agent solves 90 percent of tasks, so users will see it work nine times out
+of ten. Right?**
+
+A: Only if pass@1 was measured the way the user experiences it, and usually it is
+not. pass@k with $k \gt 1$ measures coverage: the chance that at least one of $k$
+attempts succeeds, which is the right metric when a verifier or a human picks the
+winner and the wrong one for a user with a single shot. Reliability is pass^k, all
+$k$ attempts succeeding, and it decays geometrically: a 90 percent per-attempt rate
+is about 43 percent at $k = 8$. If the reported number was a best-of-k or came from
+a suite with weak outcome validation, the real per-attempt rate is lower still.
+
+**Deeper:** The two metrics also imply different products. A high pass@k with a low
+pass^k argues for a verifier-in-the-loop design, retries plus a checker, while a
+system that cannot verify its own output needs the pass^k number to be the one on
+the slide.
+
+**Q: We ran greedy decoding once per item, so the number is deterministic and
+comparable. Right?**
+
+A: Neither, usually. Greedy is not reproducible in a batched serving system because
+kernels are not batch-invariant, and it is not comparable across candidates when
+vendors recommend different decode settings. A single greedy run also gives you no
+variance estimate, so you cannot say anything about whether a gap is real. The
+minimum honest protocol is multiple seeds with reported spread, or a demonstrated
+reproduction of the exact number on a re-run.
+
+**Q: Average all the benchmark scores into one number so leadership has a single
+metric.**
+
+A: An index is legitimate, and a naive average is not. Benchmarks have different
+chance floors (25 percent on a 4-option set, 0 percent free-form) and different
+ceilings, so averaging raw percentages weights by scale rather than importance;
+saturated components contribute noise; and an unweighted mean is still a weighting,
+just an unexamined one. Build the index properly: normalize, state the weights,
+drop saturated components, and bootstrap over items to put an interval on the index
+and on the *rank*, which is what people actually read. Then keep the per-benchmark
+table next to it, because the index cannot tell you which capability moved.
+
+**Q: Use the strongest available model as the judge; it will be the most accurate.**
+
+A: Strongest is not the same as certified. Judge-specific benchmarks exist because
+strong general models are mediocre judges on objectively checkable pairs where the
+wrong answer sounds better, and a strong judge from the same family as a candidate
+brings self-preference bias. The right procedure is to measure several candidate
+judges against a human-labeled meta-eval set, pick the cheapest that clears the
+agreement bar, probe it with degenerate inputs to make sure a constant or padded
+answer cannot score well, and then correct its remaining bias statistically with a
+small human-labeled sample rather than assuming it away.
+
+**Q: Model A scores higher across the board, so we should build on A.**
+
+A: Higher on what, at what cost, and with what interval. Three checks before that
+becomes a decision: are the gaps outside the paired confidence intervals, or is this
+a tie; was the comparison cost-matched, because a candidate given five times the
+output tokens should be compared on the frontier rather than on the score; and does
+the benchmark portfolio match our workload, since a model that wins on competition
+math and loses on our internal retrieval set is the wrong choice for a retrieval
+product. Benchmarks filter candidates; the internal set and the online loop decide.
+
+**Q: Our fine-tune beats the published base-model number, so it is an improvement.**
+
+A: Not established, because those two numbers came from different pipelines. The
+published number used the vendor's prompt, few-shot setting, token budget, and
+parser, usually chosen favorably, and possibly a different benchmark version. The
+only valid comparison re-runs the base model under exactly your protocol, on the
+same items, at the same time, and then compares paired per item. Nine times out of
+ten the re-run baseline lands somewhere other than the published figure, and the
+sign of your improvement is not always preserved.
+
+**Deeper:** This trap also generalizes to comparing across time within your own
+team. Benchmarks get patched, harness defaults change, providers update models
+behind aliases, so a number from six months ago is a different protocol even if the
+config file looks the same. Baselines are re-run, not remembered, and the protocol
+hash is what tells you whether a re-run was needed.

--- a/book/benchmark-eval/09-summary.md
+++ b/book/benchmark-eval/09-summary.md
@@ -1,0 +1,209 @@
+# 9. Summary
+
+## One-page recap
+
+- **A benchmark score is a construct, an item population, and a protocol.** Most
+  disagreements about scores are really disagreements about one of the three. Name
+  which one before arguing about the number.
+
+- **The protocol moves the number more than the model does.** Chat template, system
+  prompt, few-shot count, scoring mode, length normalization, answer-format
+  instruction, parser strictness, output-token budget, decode parameters, seeds,
+  serving stack, and provider each shift results, several of them by more than a
+  model generation. Pin them, hash them, print the hash next to the score.
+
+- **Re-run every baseline yourself.** Published numbers came from a different
+  pipeline, usually a favorable one. One harness, one protocol, all candidates,
+  compared paired per item.
+
+- **Contamination has five kinds and deduplication catches one.** Verbatim,
+  near-duplicate, format, distillation, and selection leakage. The verifiable
+  defenses are black-box: post-cutoff time splits, live and time-gated benchmarks,
+  functional twins, and a private internal set whose no-leak story you can prove.
+
+- **Broken items cap what you can measure.** Label errors on classic multiple-choice
+  suites and weak outcome validation on agentic ones both inflate or scramble
+  rankings. Audit passing agent trajectories by hand before publishing an agentic
+  number.
+
+- **Scoring is an instrument with its own error rate.** Executable checks first,
+  answer matching for short free-form, expert rubrics for open-ended. When a model
+  grades, certify it against human labels, probe it with degenerate inputs, and then
+  correct its residual bias with prediction-powered inference rather than trusting
+  it.
+
+- **Analyze evals like experiments.** Paired differences, Wilson or bootstrap
+  intervals at small $n$, clustered errors for grouped items, multiple seeds on
+  reasoning suites, false-discovery control across the grid. On a 200-item benchmark
+  a 3-point gap from one run is not resolvable, and saying so is the correct answer.
+
+- **Report cost with quality.** Test-time compute makes quality a curve. Score,
+  interval, tokens, dollars, latency, and effort setting travel together, or the
+  comparison silently rewards whoever spent more.
+
+- **Benchmarks pick a model; they never gate a feature.** The feature gate is the
+  golden set, the certified judge, and the online loop in the
+  [evaluation chapter](../evaluation/).
+
+## The system on one page
+
+```mermaid
+flowchart TD
+  DEC["what decision does<br/>the number drive?"] --> PORT["capability portfolio<br/>+ private internal set"]
+  PORT --> PIN["pin items + protocol<br/>(hash it)"]
+  PIN --> RUN["run: shard, cache,<br/>sandbox, keep raw outputs"]
+  RUN --> SC["score: executable checks,<br/>answer matching, rubric"]
+  SC --> CERT{"model grader<br/>certified?"}
+  CERT -->|"no"| FIXR["fix rubric,<br/>re-certify"]
+  CERT -->|"yes"| PPI["PPI-correct with<br/>human-labeled sample"]
+  PPI --> STAT["paired analysis<br/>+ intervals + seeds"]
+  SC --> STAT
+  STAT --> CONTAM{"contamination<br/>evidence ok?"}
+  CONTAM -->|"no"| TWIN["time split /<br/>functional twin"]
+  CONTAM -->|"yes"| CARD["report card:<br/>score + CI + cost + hash"]
+  CARD --> VERDICT{"paired CI<br/>excludes zero?"}
+  VERDICT -->|"no"| TIE["not distinguishable;<br/>state n required"]
+  VERDICT -->|"yes"| PICK["model selection<br/>or release gate"]
+```
+
+## Test yourself
+
+Answers are collapsed. Attempt each before opening one.
+
+1. A vendor reports 78 on a benchmark; your harness gives that model 66 on the same
+   benchmark. List the checks in the order you would run them, and say why that
+   order.
+
+   <details><summary>Answer</summary>
+
+   In descending order of typical effect size, because the goal is to find the one
+   knob that explains 12 points rather than to audit everything
+   ([3](03-the-harness.md)). **First, the chat template and system prompt**: applying
+   the wrong template, or omitting a preamble the vendor used, can drop a model
+   toward chance on some suites. **Second, scoring mode**: log-likelihood ranking
+   over options and generative-plus-parser are different measurements, and a chat
+   model scored by log-likelihood can look nearly random. **Third, the
+   output-token budget**: check the truncation rate, since a reasoning model cut off
+   mid-derivation is scored wrong for a reason unrelated to ability. **Fourth,
+   few-shot count and order and the answer-format instruction**, which change both
+   difficulty and parseability. **Fifth, decode parameters and sample count**, then
+   **benchmark version and item subset**. The diagnostic that short-circuits most of
+   this is printing one rendered prompt and one raw completion and reading them; the
+   bug is usually visible. The conclusion is not to reconcile with the published
+   number but to re-run every candidate, baseline included, under your own protocol
+   ([1](01-clarifying-requirements.md)).
+
+   </details>
+
+2. Two models on a 500-item benchmark: A scores 71.0, B scores 69.0. Per item, A
+   wins 25 that B loses, and B wins 15 that A loses. Is A better?
+
+   <details><summary>Answer</summary>
+
+   Not established. The paired difference is $(25-15)/500 = 2$ points with standard
+   error $\sqrt{25+15}/500 \approx 1.3$ points, so McNemar's
+   $z = 10/\sqrt{40} \approx 1.6$, which does not clear 1.96
+   ([6](06-statistics-and-leaderboards.md)). Note how much the pairing bought: the
+   unpaired interval on each score alone is about 4.4 points, which would have made
+   the comparison look hopeless, while paired it is merely inconclusive and you can
+   compute exactly what would settle it. At a discordance rate of $40/500 = 0.08$
+   and a 2-point target, $n \approx 0.08 \cdot 7.85 / 0.02^2 \approx 1{,}570$ items.
+   So the correct report is "not distinguishable at this sample size, about 1,600
+   items needed," plus a check of seed variance, which on small suites often exceeds
+   the effect under discussion.
+
+   </details>
+
+3. Your grader is a model. You have budget for 300 human labels but the benchmark
+   has 5,000 items. What do you do with the 300, and why is that better than
+   labeling 300 items and reporting those?
+
+   <details><summary>Answer</summary>
+
+   Use them as the correction term in a prediction-powered estimate rather than as a
+   standalone sample ([5](05-scoring-and-autoraters.md)). Run the grader on all
+   5,000, run humans on 300 that the grader also scored, and report
+   $\hat\theta = \text{mean}(\text{judge over } 5{,}000) + \text{mean}(\text{human} - \text{judge over } 300)$.
+   The second term is an unbiased estimate of the grader's systematic error, so the
+   result is unbiased no matter how biased the grader is, while the first term
+   contributes the precision of 5,000 items. Reporting the 300 alone throws away the
+   other 4,700 and gives a much wider interval; reporting the grader alone is
+   precise and biased. Stratify the 300 across slices rather than sampling uniformly,
+   and oversample near the decision boundary when you are also certifying the grader.
+   Two disciplines come with it: report the grader's own error rate, since no
+   comparison finer than that rate is supportable, and re-collect labels when the
+   distribution moves.
+
+   </details>
+
+4. A benchmark suite you inherited scores an agent as passing 68 percent of tasks.
+   What do you check before that number leaves the room?
+
+   <details><summary>Answer</summary>
+
+   Four things, in order ([4](04-contamination-and-validity.md),
+   [3](03-the-harness.md)). **Outcome validation**: manually audit a sample of
+   passing trajectories, because audits of widely used agentic benchmarks found test
+   suites weak enough to accept incorrect solutions and criteria that can score
+   inaction as success, which inflates scores substantially. **Environment
+   provenance**: is the container pinned by digest, is the network policy the
+   benchmark's own, and how many items needed retries; a suite with a material retry
+   rate is reporting infrastructure. **The metric**: 68 percent per attempt is not 68
+   percent as experienced if the user gets one shot, so report pass^k alongside, and
+   note that $0.68^3$ is about 31 percent. **Cost**: steps, tokens, and dollars per
+   task, since an agent that succeeds by brute-forcing 200 tool calls is a different
+   product decision from one that succeeds in 8.
+
+   </details>
+
+5. Leadership wants one headline number across 15 benchmarks. What do you build, and
+   what do you refuse?
+
+   <details><summary>Answer</summary>
+
+   Build a normalized, explicitly weighted index with a bootstrap interval on both
+   the index and the rank, drop the saturated components, and keep the
+   per-benchmark table adjacent ([6](06-statistics-and-leaderboards.md)). Refuse the
+   naive average of raw percentages: chance floors differ (25 percent on a 4-option
+   set versus 0 percent free-form) and ceilings differ, so it weights by scale rather
+   than importance, and it hides which capability moved. Also refuse to publish the
+   index without the rank interval, because rank stability is what readers consume
+   and it is usually far weaker than the point estimates suggest. The honest framing
+   for leadership is that the index is a screening device and the internal benchmark
+   is the decision-maker of record.
+
+   </details>
+
+6. Someone proposes evaluating on your test set weekly during a training run, and
+   picking the checkpoint that scores best. What is wrong, and what do you propose
+   instead?
+
+   <details><summary>Answer</summary>
+
+   That is selection leakage: nothing entered the training data, but the reported
+   number becomes a maximum over many looks rather than an unbiased estimate, and
+   the gap grows with the number of looks ([4](04-contamination-and-validity.md)).
+   The proposal instead is the standard three-way split adapted to evals: a
+   development set you may query freely for checkpoint selection, and a sealed slice
+   with an explicit query budget, logged, where each look is recorded and a
+   checkpoint chosen on it consumes a look. Report the final number from the sealed
+   slice with its query count attached. This is the same discipline that makes
+   leaderboard best-of-N submission a known bias ([The Leaderboard
+   Illusion](https://arxiv.org/abs/2504.20879)): the number of variants tried before
+   publishing one is part of the result.
+
+   </details>
+
+## Further reading
+
+- The capstone: [the complete build](10-putting-it-together.md), where the whole
+  pipeline is decided once, costed, re-derived under three constraint sets, and
+  compressed into a runnable statistics reference.
+- Reproducibility and protocol: [Lessons from the Trenches on Reproducible Evaluation of Language Models](https://arxiv.org/abs/2405.14782).
+- Statistics: [Adding Error Bars to Evals](https://arxiv.org/abs/2411.00640) and [Don't Use the CLT in LLM Evals With Fewer Than a Few Hundred Datapoints](https://arxiv.org/abs/2503.01747).
+- Reasoning-suite variance: [A Sober Look at Progress in Language Model Reasoning](https://arxiv.org/abs/2504.07086).
+- Contamination: [Recent Advances in LLM Benchmarks against Data Contamination](https://arxiv.org/abs/2502.17521) and [A Careful Examination of LLM Performance on Grade School Arithmetic](https://arxiv.org/abs/2405.00332).
+- Agentic rigor: [Establishing Best Practices for Building Rigorous Agentic Benchmarks](https://arxiv.org/abs/2507.02825).
+- Judge correction: [Stratified Prediction-Powered Inference](https://arxiv.org/abs/2406.04291) and [How to Correctly Report LLM-as-a-Judge Evaluations](https://arxiv.org/abs/2511.21140).
+- Format validity: [Answer Matching Outperforms Multiple Choice](https://arxiv.org/abs/2507.02856).
+- The product-side companion: [evaluating LLM systems](../evaluation/).

--- a/book/benchmark-eval/10-putting-it-together.md
+++ b/book/benchmark-eval/10-putting-it-together.md
@@ -1,0 +1,261 @@
+# 10. Putting it together: the complete build
+
+Every earlier section presented options. This one commits: one stack, decided, with
+the run costed, then re-derived under three different constraint sets, and closed
+with a runnable reference you can execute with nothing but Python 3.
+
+The scenario is the one from [section 1](01-clarifying-requirements.md): choose a
+base model for a product family from three candidates (two API models, one
+open-weight model we host), while tracking our own fine-tunes on the same protocol,
+with the requirement that a 2-point difference be callable.
+
+## The default stack
+
+| Decision | Committed choice | Why, in one line |
+|---|---|---|
+| Portfolio | 3 public suites with headroom, 1 live suite, 2 agentic suites, 1 private internal set | Capability coverage plus a contamination check plus a decision-maker of record |
+| Scoring mode | Generative plus answer matching everywhere; log-likelihood only for base-model training telemetry | Matches how the model is used and works on API candidates |
+| Open-ended grading | Per-item rubric criteria, model grader, certified against expert labels | Holistic scores do not reproduce; criteria are debuggable |
+| Judged numbers | PPI-corrected with 300 expert labels per candidate | Unbiased regardless of grader quality, at a labeling cost you can size |
+| Decode policy | One policy per benchmark applied to all candidates, vendor-recommended settings checked on a subset | Comparability first, with a sanity check that the policy is not penalizing anyone |
+| Test-time compute | Two effort levels for the reasoning-capable candidates | Quality is a curve against spend, not a scalar |
+| Seeds | 5 on suites under 300 items, 3 on agentic, 1 on suites over 1,000 items | Variance where variance dominates, items where items dominate |
+| Statistics | Paired per-item comparison, bootstrap interval on the difference, BH correction across the pre-registered comparisons | The gap, not the scores, is the quantity of interest |
+| Contamination evidence | Live-suite window after every candidate's cutoff, plus the internal set | Runnable by anyone, unlike a decontamination claim |
+| Artifact | Report card with score, interval, cost, protocol hash, and per-comparison verdict | A number without its protocol is not reproducible |
+
+## The run, costed
+
+Item counts and sample budget per candidate:
+
+| Suite | Items | Seeds | Runs | Kind |
+|---|---|---|---|---|
+| GPQA Diamond | 198 | 5 | 990 | Short-answer reasoning |
+| MMLU-Pro subset | 1,000 | 1 | 1,000 | Broad knowledge |
+| LiveCodeBench (post-cutoff window) | 300 | 3 | 900 | Code, contamination check |
+| Internal set | 800 | 3 | 2,400 | Rubric-graded open-ended |
+| SWE-bench Verified | 500 | 1 | 500 | Agentic, repo environment |
+| tau2-bench | 300 | 3 | 900 | Agentic, tool plus user simulation |
+
+Item counts here are the slices this run evaluates, not the full published size of
+each suite: the MMLU-Pro row is a sampled subset, the LiveCodeBench row is a
+release-date window after every candidate's cutoff, and the agentic rows are the
+task sets we chose to run. GPQA Diamond and SWE-bench Verified are run whole.
+
+The cost is dominated by two things people underestimate: agentic episodes, where
+the context is re-sent on every tool turn, and the effort curve, which multiplies
+the reasoning suites. Using illustrative prices of \$3 per million input tokens and
+\$15 per million output tokens:
+
+```text
+non-agentic   5,290 runs x (1.5k in + 3k out)   ~=  7.9M in + 15.9M out  ~= $262
+SWE-bench       500 episodes x (120k in + 15k out) ~= 60M in +  7.5M out ~= $292
+tau2-bench      900 episodes x (40k in + 6k out)   ~= 36M in +  5.4M out ~= $189
+                                                       per candidate     ~= $743
+3 candidates                                                             ~= $2,230
+high-effort curve on 2 candidates (reasoning suites, 3x output)          ~=   $400
+rubric grading 7,200 grader calls on a cheap model                       ~=    $30
+                                                       total compute     ~= $2,700
+```
+
+The other budget line is human labeling: 300 expert judgments per candidate for the
+PPI correction, roughly 900 judgments at a few minutes each, which is one to two
+expert-weeks and the real constraint on cadence. Wall clock at 30-way parallelism is
+a few hours for the non-agentic suites and most of a day for the agentic ones, so
+the full grid is an overnight job and the smoke subset is a coffee break.
+
+That ratio, two thousand dollars of compute against two expert-weeks of labeling, is
+the reason PPI matters: the cheap resource is model calls and the scarce one is
+judgment, so the design should spend the former to stretch the latter.
+
+## The report card
+
+What lands in the document, per benchmark, with the aggregate kept separate:
+
+| Candidate | Internal set (PPI) | 95% CI | GPQA-D | LiveCodeBench | tau2 pass^1 | tau2 pass^3 | Out tokens per item | \$ per 1k items |
+|---|---|---|---|---|---|---|---|---|
+| A (medium effort) | 0.678 | +/- 0.031 | 0.61 | 0.44 | 0.68 | 0.31 | 3,100 | \$48 |
+| A (high effort) | 0.702 | +/- 0.030 | 0.69 | 0.52 | 0.71 | 0.36 | 9,400 | \$142 |
+| B (default) | 0.671 | +/- 0.032 | 0.64 | 0.49 | 0.66 | 0.29 | 1,400 | \$23 |
+| C (open weight, self-hosted) | 0.639 | +/- 0.033 | 0.55 | 0.41 | 0.58 | 0.20 | 1,900 | \$9 |
+
+Illustrative numbers, but the shape is the point. Read as scores, A-high wins. Read
+as the report card: A-high costs six times B for a gap on the internal set whose
+paired interval very likely includes zero, C is a third of B's quality gap away at a
+fraction of the cost and might win once serving volume is priced in, and every
+candidate's pass^3 on the agentic suite is roughly half its pass^1, which is the
+number the product team needs to see before promising an autonomous flow.
+
+The verdicts that go with it: **B as the default**, **A-high as an escalation tier
+for hard items** (which is the [cost-optimization chapter's](../cost-optimization/)
+cascade, now justified with numbers), **C revisited if volume grows**, and **the
+A-versus-B internal-set gap reported as not distinguishable** with the item count
+that would settle it.
+
+## The same system under three constraint sets
+
+**Frontier lab training its own models.** The bottleneck moves from cost to cadence:
+you need a signal per checkpoint, not per quarter. Split into a cheap proxy suite
+(a few hundred items, log-likelihood scored, run every few thousand steps) and the
+full grid at milestones only. Decontamination becomes real work rather than a claim,
+because you own the corpus: n-gram and near-duplicate removal of benchmark items and
+their paraphrases, plus the caveat that distillation from an external teacher can
+reintroduce leakage you cannot see. Add a sealed slice with a logged query budget,
+because with hundreds of checkpoints selection leakage is the dominant risk, not
+training-set overlap. Deterministic serving matters more here than anywhere else,
+since a training-telemetry curve that moves with batch composition is unreadable.
+
+**Seed-stage startup on API models.** Drop to one seed on the large suites, keep
+multiple seeds only where the item count is small, and cut the public portfolio to
+two suites plus one live suite. Spend everything you save on the internal set,
+because it is the only thing that decides your product, and on 200 human labels for
+the PPI correction. Skip self-hosting comparisons until volume justifies them. The
+honest posture in a fundraising deck is a protocol hash and an interval next to the
+number, which is cheap and immediately distinguishes you from a screenshot of a
+leaderboard.
+
+**Regulated or safety-critical domain.** The rubric is written by domain experts and
+versioned like code; the grader is certified against expert labels per rubric
+version and re-certified on a schedule. A safety suite runs as a separate blocking
+gate with its own threshold, paired with a benign set so over-refusal is measured
+rather than rewarded. Every run is retained for audit with full provenance
+(protocol hash, container digest, raw outputs), and a human sign-off sits after the
+automated gate, because the automated pipeline reduces the volume that needs expert
+attention rather than eliminating it.
+
+## The smallest runnable experiment
+
+One file, standard library only. It answers the four questions a benchmark report
+has to answer, and it reproduces the central lesson of
+[section 6](06-statistics-and-leaderboards.md): a 2-point gap on a 500-item
+benchmark is not a result.
+
+```python
+"""Benchmark-eval statistics on one page. Python 3, standard library only."""
+
+import random
+from math import comb, sqrt
+
+random.seed(10)
+
+# Per-item correctness for two candidates on the SAME 500 items (paired by index).
+# Items carry a shared difficulty, so the two models agree on most of them; only a
+# thin band plus per-run noise separates them. That correlation is exactly what the
+# paired analysis exploits and the unpaired one throws away.
+N, SKILL_A, SKILL_B, NOISE = 500, 0.72, 0.70, 0.05
+difficulty = [random.random() for _ in range(N)]          # shared across candidates
+
+
+def run(skill):
+    return [int((d < skill) != (random.random() < NOISE)) for d in difficulty]
+
+
+a, b = run(SKILL_A), run(SKILL_B)
+
+
+def wilson(k, n, z=1.96):
+    """95% interval for a proportion. Correct at small n, unlike the normal approx."""
+    p = k / n
+    d = 1 + z * z / n
+    center = (p + z * z / (2 * n)) / d
+    half = z * sqrt(p * (1 - p) / n + z * z / (4 * n * n)) / d
+    return center - half, center + half
+
+
+def mcnemar(x, y):
+    """Paired comparison: only items where the two disagree carry information."""
+    b_wins = sum(1 for u, v in zip(x, y) if u == 1 and v == 0)   # x right, y wrong
+    c_wins = sum(1 for u, v in zip(x, y) if u == 0 and v == 1)   # y right, x wrong
+    delta = (b_wins - c_wins) / len(x)
+    se = sqrt(b_wins + c_wins) / len(x)
+    z = (b_wins - c_wins) / sqrt(b_wins + c_wins) if b_wins + c_wins else 0.0
+    return delta, se, z, b_wins, c_wins
+
+
+def paired_bootstrap(x, y, reps=5000):
+    """Resample items (not scores) to get an interval on the difference."""
+    n = len(x)
+    diffs = []
+    for _ in range(reps):
+        idx = [random.randrange(n) for _ in range(n)]
+        diffs.append(sum(x[i] - y[i] for i in idx) / n)
+    diffs.sort()
+    return diffs[int(0.025 * reps)], diffs[int(0.975 * reps)]
+
+
+def items_needed(discordance, delta, z_sum=2.80):
+    """Items required to detect `delta` at 5% significance and 80% power, paired."""
+    return discordance * (z_sum / delta) ** 2
+
+
+def pass_hat_k(n, c, k):
+    """Reliability: P(all k independent attempts succeed), unbiased from n trials."""
+    return 0.0 if c < k else comb(c, k) / comb(n, k)
+
+
+def ppi(judge_all, judge_labeled, human_labeled):
+    """Judge mean, rectified by the judge's measured bias on the human-labeled slice."""
+    bias = sum(h - j for h, j in zip(human_labeled, judge_labeled)) / len(human_labeled)
+    return sum(judge_all) / len(judge_all) + bias
+
+
+lo_a, hi_a = wilson(sum(a), N)
+lo_b, hi_b = wilson(sum(b), N)
+delta, se, z, bw, cw = mcnemar(a, b)
+blo, bhi = paired_bootstrap(a, b)
+
+print(f"A = {sum(a)/N:.3f}  95% CI [{lo_a:.3f}, {hi_a:.3f}]   (unpaired)")
+print(f"B = {sum(b)/N:.3f}  95% CI [{lo_b:.3f}, {hi_b:.3f}]   (unpaired)")
+print(f"paired: delta={delta:+.3f}  se={se:.3f}  mcnemar z={z:.2f}  "
+      f"(A-only {bw}, B-only {cw})")
+print(f"paired bootstrap 95% CI on the difference: [{blo:+.3f}, {bhi:+.3f}]")
+print("verdict:", "distinguishable" if blo > 0 or bhi < 0 else "NOT distinguishable")
+d = (bw + cw) / N
+print(f"discordance={d:.3f} -> items needed for a 2-point call: "
+      f"{items_needed(d, 0.02):,.0f}")
+
+print()
+for p in (0.9, 0.68):
+    n_trials, c_ok = 100, int(round(100 * p))
+    print(f"per-attempt {p:.0%}: pass^3={pass_hat_k(n_trials, c_ok, 3):.2f}  "
+          f"pass^8={pass_hat_k(n_trials, c_ok, 8):.2f}")
+
+print()
+judged = [1 if random.random() < 0.74 else 0 for _ in range(5000)]   # judge, all items
+sub = list(range(300))                                               # human-labeled slice
+judge_sub = [judged[i] for i in sub]
+# humans are stricter than the judge on ~8% of the items it passed
+human_sub = [0 if (j == 1 and random.random() < 0.08) else j for j in judge_sub]
+print(f"judge-only estimate : {sum(judged)/len(judged):.3f}   (precise, biased)")
+print(f"humans-only (n=300) : {sum(human_sub)/len(human_sub):.3f}   (unbiased, wide)")
+print(f"PPI-corrected       : {ppi(judged, judge_sub, human_sub):.3f}   "
+      f"(unbiased, narrow)")
+```
+
+Output:
+
+```text
+A = 0.712  95% CI [0.671, 0.750]   (unpaired)
+B = 0.690  95% CI [0.648, 0.729]   (unpaired)
+paired: delta=+0.022  se=0.015  mcnemar z=1.46  (A-only 34, B-only 23)
+paired bootstrap 95% CI on the difference: [-0.006, +0.052]
+verdict: NOT distinguishable
+discordance=0.114 -> items needed for a 2-point call: 2,234
+
+per-attempt 90%: pass^3=0.73  pass^8=0.42
+per-attempt 68%: pass^3=0.31  pass^8=0.04
+
+judge-only estimate : 0.742   (precise, biased)
+humans-only (n=300) : 0.683   (unbiased, wide)
+PPI-corrected       : 0.678   (unbiased, narrow)
+```
+
+Three things to take from twenty lines of output. **A is 2.2 points ahead and that
+is not a result**: the paired bootstrap interval crosses zero, and it would take
+roughly 2,200 items to settle a gap that size. **Pairing bought most of the
+precision available**: the unpaired intervals are about 4 points wide each, the
+paired standard error is 1.5 points. **The judge's number is precise and wrong**:
+0.742 against a corrected 0.678, a 6-point bias that 300 honest labels both revealed
+and removed. Every one of those is a sentence you can say in an interview, and each
+one is the kind of claim that only sounds credible when you can show where the
+number came from.

--- a/book/benchmark-eval/README.md
+++ b/book/benchmark-eval/README.md
@@ -1,0 +1,58 @@
+# Benchmarking a Model: The Evaluation Pipeline End to End
+
+The companion [evaluation chapter](../evaluation/) answers "is my *feature* good?"
+This chapter answers the other question labs and platform teams actually get asked:
+**"here is a model. Produce a number I can bet a launch on, and defend every step of
+how you got it."**
+
+An interviewer rarely says "design a benchmark harness." They say something like:
+**"We are choosing between three candidate models and we also fine-tuned our own.
+Walk me through the whole evaluation pipeline. How do you know the numbers mean
+anything?"** The follow-ups are always the same three: *why does your number differ
+from the published one, how do you know a 2-point gap is real, and how do you know
+the model has not already seen the test set.*
+
+That is a systems question, not a metrics question. A benchmark score is the output
+of a pipeline with roughly a dozen knobs, most of which move the number by more than
+the model difference you are trying to measure.
+
+## Sections
+
+1. [Clarifying the requirements](01-clarifying-requirements.md) - the dialogue that scopes what decision the number drives, and the two consequences that fall out.
+2. [Framing the benchmark](02-frame-the-benchmark.md) - construct, item population, protocol; the 2026 benchmark families; saturation, headroom, and construct validity.
+3. [The harness](03-the-harness.md) - the whole pipeline mechanically: prompt rendering, decoding, answer extraction, scoring, provenance, determinism, and running it at scale.
+4. [Contamination and item validity](04-contamination-and-validity.md) - leakage types, detection methods (n-gram, Min-K%, time splits, functional twins), live benchmarks, and broken items.
+5. [Scoring and autoraters](05-scoring-and-autoraters.md) - answer matching vs multiple choice, rubric grading, pass@k vs pass^k, certifying a model grader, and bias-corrected estimation.
+6. [Statistics and leaderboards](06-statistics-and-leaderboards.md) - error bars, paired tests, seed variance, multiple comparisons, aggregation, arena ranking, and cost-matched comparison.
+7. [How teams do it in production](07-how-teams-do-it-in-production.md) - where real eval stacks diverge; named comparison with first-party links.
+8. [Interview Q&A](08-interview-qa.md) - commonly asked, tricky, and commonly answered wrong.
+9. [Summary](09-summary.md) - one-page recap, mermaid, test-yourself questions, further reading.
+10. [Putting it together: the complete build](10-putting-it-together.md) - a default stack, the full run costed, the same system under three constraint sets, and a runnable zero-dependency statistics reference.
+
+## The pipeline on one page
+
+```mermaid
+flowchart TD
+  SEL["benchmark selection<br/>(capability portfolio + headroom)"] --> ITEMS["item store<br/>(pinned version, licence, release dates)"]
+  ITEMS --> DECON["contamination control<br/>(time split, n-gram, functional twins)"]
+  DECON --> RENDER["prompt rendering<br/>(chat template, few-shot, answer format)"]
+  RENDER --> GEN["generation<br/>(decode params, token budget, N samples)"]
+  GEN --> PARSE["extraction<br/>(parser, verifier, sandbox run)"]
+  PARSE --> SCORE["scoring<br/>(exact / answer match / rubric / tests)"]
+  SCORE --> AGG["aggregation<br/>(per-slice, per-seed, with error bars)"]
+  AGG --> DEC{"is the gap real?<br/>paired CI excludes 0"}
+  DEC -->|"no"| MORE["more items / more seeds<br/>or report as a tie"]
+  DEC -->|"yes"| REPORT["report card<br/>score + CI + cost + protocol hash"]
+  REPORT --> GATE["model selection<br/>or release gate"]
+  GATE -.->|"internal eval + online loop"| SEL
+```
+
+Every arrow in that diagram is a place a number goes wrong, and the interview lives
+in the arrows, not the boxes.
+
+## Companion chapters
+
+- [Evaluating LLM systems](../evaluation/) is the product-side loop: golden sets, LLM-as-judge calibration, regression gates, online A/B. Benchmarks feed the *model selection* step upstream of it; they never gate a feature.
+- [Data curation and pretraining](../data-and-pretraining/) owns training-side decontamination, which is the only place contamination can actually be fixed.
+- [Continued pretraining and long context](../continued-pretraining/) covers long-context evaluation in the context of extending a model.
+- The classic-ML companion book covers the statistics of online comparison in [experimentation](https://github.com/neurarch-ai/awesome-ml-system-design/tree/main/book/experimentation/).

--- a/book/evaluation/03-offline-eval.md
+++ b/book/evaluation/03-offline-eval.md
@@ -78,6 +78,12 @@ borrowing from how they report:
 Use these as the coarse capability filter and the live-numbers reference; then run
 your own task-specific eval, because a public number never gates your feature.
 
+Running those benchmarks yourself is its own pipeline, and it is a common interview
+topic in its own right ("walk me through how you evaluate a model on a benchmark").
+The protocol knobs that make two runs of the same benchmark disagree, contamination
+detection, certifying a model grader, and the statistics that decide whether a gap
+is real are all in the [benchmarking chapter](../benchmark-eval/).
+
 The reason is contamination (benchmark items, or near-copies of them, leaking into
 the model's training data). If eval cases or near-duplicates leaked into a
 model's training data, its scores look inflated on public benchmarks while the

--- a/book/evaluation/04-llm-as-judge.md
+++ b/book/evaluation/04-llm-as-judge.md
@@ -110,6 +110,42 @@ tolerance to compensate for a bad instrument; fix the instrument. A low kappa
 means the judge is measuring something other than what humans care about, and
 gating on it gives false confidence.
 
+## Beyond kappa: certify, ensemble, and correct
+
+Kappa tells you the judge disagrees with humans at some rate. It does not make the
+number you report unbiased, and three newer practices close that gap. All three are
+developed in full in the [benchmarking chapter](../benchmark-eval/05-scoring-and-autoraters.md).
+
+**Rubric criteria instead of a holistic score.** Replace "rate this 1 to 10" with a
+list of per-item criteria, each nearly binary and each carrying a weight, and let the
+judge decide criterion by criterion. Models and humans agree far more on small
+checkable claims than on a global rating, and the rubric is an artifact you can
+version and hand to a domain expert. OpenAI's HealthBench is the reference design,
+with physician-written criteria per conversation and an expert meta-evaluation of the
+grader itself ([HealthBench](https://arxiv.org/abs/2505.08775)).
+
+**Probe the judge for gaming before trusting it.** Run degenerate inputs through the
+rubric: an empty answer, a constant answer, a padded answer, and an answer containing
+an instruction aimed at the judge. Any of them scoring well is a blocking defect, and
+constant-output "null models" have been shown to win non-trivial rates against
+automatic judges. Judge-specific benchmarks exist for the same reason: strong general
+models are mediocre judges on objectively checkable pairs where the wrong answer
+sounds better ([JudgeBench](https://arxiv.org/abs/2410.12784)).
+
+**Correct the residual bias statistically instead of assuming it away.** Keep the
+cheap judge on all $N$ examples, keep human labels on a small $n$, and rectify:
+
+$$\hat\theta_{\text{PPI}} = \frac{1}{N}\sum_{i=1}^{N} f(X_i) + \frac{1}{n}\sum_{j=1}^{n}\bigl(Y_j - f(X_j)\bigr)$$
+
+where $f$ is the judge score and $Y$ the human label. The second term is an unbiased
+estimate of the judge's systematic error, so the result is unbiased no matter how
+biased the judge is, and a better judge buys a tighter interval rather than a
+different answer ([Stratified Prediction-Powered Inference](https://arxiv.org/abs/2406.04291),
+[How to Correctly Report LLM-as-a-Judge Evaluations](https://arxiv.org/abs/2511.21140)).
+The practical effect is that the question stops being "can we afford to label
+everything" and becomes "how many labels buy an acceptable interval," which is a
+sizing calculation you can put in a plan.
+
 ## Pairwise vs pointwise: when to use which
 
 | Reach for | When | Instead of |

--- a/book/evaluation/08-interview-qa.md
+++ b/book/evaluation/08-interview-qa.md
@@ -183,6 +183,25 @@ an online canary before full rollout.
 
 **Deeper:** The judge's blindness is categorical, not a matter of accuracy. It cannot observe whether the user kept the output, retried, or churned, because those signals simply do not exist at eval time. No amount of judge quality recovers a variable that is structurally absent from the offline input, which is why online validation is a different measurement rather than a more precise version of the same one.
 
+**Q: Our judge clears the kappa bar, so we can report its scores as the quality
+number.**
+
+A: Clearing the bar makes the judge usable for *ranking* two candidates on the same
+rubric; it does not make its absolute number unbiased. Kappa says the judge and
+humans disagree at some rate, which is a property of the instrument, not a
+correction to the measurement. If the number leaves the team (a report, a model
+card, a launch review), rectify it: keep the judge on all examples, keep human
+labels on a few hundred, and add the measured judge bias back to the judge's mean
+(prediction-powered inference). That is unbiased regardless of judge quality, and it
+costs a labeling budget you can size rather than a labeling budget you cannot
+afford. See [benchmarking, section 5](../benchmark-eval/05-scoring-and-autoraters.md).
+
+**Deeper:** The distinction is between a relative and an absolute claim. "Candidate
+beats baseline on this rubric" survives a biased judge as long as the bias applies
+equally to both, which is why gating works. "Our assistant is 74 percent accurate"
+does not, because that number inherits the judge's bias directly, and it is the one
+that ends up on a slide.
+
 **Q: Set the gate tolerance to zero: any regression at all blocks the deploy.**
 
 A: Judge noise means a tolerance of zero will flap the gate constantly. The judge

--- a/book/evaluation/README.md
+++ b/book/evaluation/README.md
@@ -46,7 +46,14 @@ flowchart TD
 Read the sections in order the first time; they build on each other. Each opens
 with the question an interviewer actually asks, then answers it.
 
-## Companion chapter
+## Companion chapters
+
+[Benchmarking a model](../benchmark-eval/) is the other half of "eval": this chapter
+gates a *feature* on your own golden set, that one produces a defensible number for a
+*model* on public and internal benchmarks. Go there for the harness and protocol
+knobs that make published numbers irreproducible, contamination detection, autorater
+certification and bias correction, and the statistics that decide whether a gap is
+real.
 
 The classic-ML companion book covers the same ground from the other side:
 [experimentation](https://github.com/neurarch-ai/awesome-ml-system-design/tree/main/book/experimentation/) is the A/B platform underneath the online half of this chapter: randomization units, power and sizing, peeking, and interleaving.


### PR DESCRIPTION
Four commits. Three new chapters, one renamed phase, figures, and three companion pages.

## New chapters

**`book/benchmark-eval/`** answers the model-level half of "eval": produce a defensible number for a model on benchmarks and defend every step. Harness protocol (the knobs that make published numbers irreproducible), contamination detection (five leakage kinds, time splits, functional twins, membership inference), scoring (answer matching, rubric grading, pass@k vs pass^k), certifying and PPI-correcting a model grader, and the statistics that decide whether a gap is real.

**`book/model-compression/`** fills a gap where pruning existed only in `deep-dives.md` and compression had no landing place. Where the bytes and microseconds go, quantization and the outlier problem (LLM.int8, SmoothQuant, AWQ, GPTQ, rotations), pruning shapes and what each actually accelerates, distillation and prune-then-distill, serving (kernels, mixed precision, adapters, on-device), and an acceptance test built on flip rate rather than benchmark averages.

**`book/reasoning-serving/`** fills the largest remaining gap: RLVR and GRPO were covered on the training side, but "thinking token", "reasoning budget", and "test-time" appeared nowhere in inference-serving, cost-optimization, or agents. Covers output length as a random variable and what it does to the tail (Pollaczek-Khinchine, head-of-line blocking), budget caps and forced-answer boundaries, effort routing vs cascades with the breakeven arithmetic, verification as the multiplier on sampling, and cost per solved task.

## Also

- **Mid-training named as a phase.** `continued-pretraining/03` retitled "The mid-training phase" and opens with the lab-side view (mixture reweighting, microanneals as both experiment and data-quality probe, the anneal phase, capability injection and RL readiness) before the DAPT mechanics. Cross-linked from data-and-pretraining and llm-lifecycle.
- **Figures.** Four each for benchmark-eval and model-compression, generated from the same formulas as the text, with the generator scripts checked in.
- **Structured output.** Constrained decoding, schema design, repair-before-retry, and call validity as a tracked rate added to `agents/03` with a trap Q&A; `rag-serving` points at it.
- **Companion pages.** `reading-paths.md` (per-role and one-week orders), `numbers-to-know.md` (quantities to produce from memory, each with its formula), `mock-interview.md` (a full 45-minute transcript with the interviewer's scoring notes and rubric).
- **Discoverability.** New chapters registered in the root README and the question bank, which previously had no route to them.
- Newer judge methods threaded into the existing `evaluation` chapter (rubric criteria, gaming probes, PPI), with a trap Q&A about reporting raw judge scores.

## Gates

- `node tools/validate-book.mjs`: 214 files clean
- `python3 tools/run-capstones.py`: all 19 capstone runnables pass; each new capstone's pasted output matches a real run
- `node tools/check-links.mjs`: 321 URLs, 0 dead

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 4. topics/ counterparts

The three new chapters were book-only, so the repo root, the topics index, and the question bank had no route to them. Adds `topics/16-benchmark-evaluation.md`, `topics/17-model-compression.md`, and `topics/18-reasoning-and-test-time-compute.md` in the dense walkthrough shape, registers them in the topics index and the root README tables, and cross-links each book chapter to its topic and back.
