### PR TITLE
topics: benchmark evaluation, model compression, and reasoning/test-time compute

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ watch it.**
 | 02 | [Long-context inference and the KV cache](topics/02-long-context-and-kv-cache.md) | The real cost of serving, GQA vs MLA, paged attention, prefix caching, batching |
 | 04 | [LLM inference serving at scale](topics/04-inference-serving-at-scale.md) | Continuous batching, speculative decoding, tensor parallelism, autoscaling |
 | 11 | [Cost optimization and model routing](topics/11-cost-optimization-and-model-routing.md) | Model routing, cascades, semantic caching, prompt compression, right-sizing, the quality-cost frontier |
+| 17 | [Model compression](topics/17-model-compression.md) | Quantization and the outlier problem, pruning shapes the hardware can use, distillation, on-device, the acceptance test |
+| 18 | [Reasoning and test-time compute](topics/18-reasoning-and-test-time-compute.md) | Thinking budgets, the latency tail, effort routing and cascades, verifiers, cost per solved task |
 | 10 | [Realtime streaming chat](topics/10-realtime-streaming-chat.md) | Token streaming, session memory, websockets, backpressure |
 
 ### Retrieval and knowledge
@@ -108,22 +110,11 @@ watch it.**
 | # | Topic | What it teaches |
 |---|-------|-----------------|
 | 06 | [LLM evaluation system](topics/06-evaluation-system.md) | Offline suites, LLM-as-judge, online A/B, regression gates |
+| 16 | [Benchmarking a model](topics/16-benchmark-evaluation.md) | Harness and protocol, contamination, autorater certification and PPI, error bars, leaderboards |
 | 07 | [Safety, moderation, and guardrails](topics/07-safety-and-guardrails.md) | Input/output filtering, jailbreak defense, PII, policy routing |
 | 12 | [Production monitoring and observability](topics/12-production-monitoring-and-observability.md) | Tracing, online eval without labels, LLM-as-judge, hallucination detection, drift, regression |
 
-All fifteen topics are written and ready.
-
-### Book-only chapters
-
-Three subjects are covered in the book edition and have no `topics/` counterpart
-yet. They are written in the same shape (dialogue, deep dives, production
-comparison, interview Q&A, runnable capstone).
-
-| Chapter | What it teaches |
-|---|---|
-| [Benchmarking a model](book/benchmark-eval/) | The benchmark pipeline end to end: harness and protocol, contamination detection, autorater certification and bias correction, error bars, leaderboards |
-| [Model compression](book/model-compression/) | Quantization and the outlier problem, pruning shapes the hardware can use, distillation, on-device serving, and the acceptance test a compressed model must pass |
-| [Reasoning and test-time compute](book/reasoning-serving/) | Serving models that think: token budgets, latency variance, effort routing, verifiers and best-of-n, when a reasoning model is the wrong choice |
+All eighteen topics are written and ready.
 
 **Going deeper than the whiteboard?** [**deep-dives.md**](deep-dives.md) is a
 bank of ~206 rapid-fire, depth-probing questions: the follow-ups an interviewer

--- a/book/benchmark-eval/07-how-teams-do-it-in-production.md
+++ b/book/benchmark-eval/07-how-teams-do-it-in-production.md
@@ -54,3 +54,6 @@ suites plus one internal set. Publishing a model-card number does not.
 - **UIUC and collaborators** [Establishing Best Practices for Building Rigorous Agentic Benchmarks](https://arxiv.org/abs/2507.02825): the checklist for task specification and outcome validation, with measured overestimation in widely used agentic benchmarks.
 - **Thinking Machines Lab** [Defeating Nondeterminism in LLM Inference](https://thinkingmachines.ai/blog/defeating-nondeterminism-in-llm-inference/): why identical requests differ, and batch-invariant kernels that fix it.
 - **Epoch AI** [benchmarking hub](https://epoch.ai/benchmarks): independently re-run benchmark results with the protocol documented.
+
+For the dense single-file reference (same material, interview-walkthrough shape):
+[topics/16-benchmark-evaluation.md](../../topics/16-benchmark-evaluation.md).

--- a/book/model-compression/07-how-teams-do-it-in-production.md
+++ b/book/model-compression/07-how-teams-do-it-in-production.md
@@ -53,3 +53,6 @@ like server stacks even when both say "4-bit."
 - **Microsoft Research India** [Accuracy is Not All You Need](https://arxiv.org/abs/2407.09141): why compressed models that match on accuracy still behave differently, and what to measure instead.
 - **Red Hat AI and the vLLM project** [llm-compressor](https://github.com/vllm-project/llm-compressor): production recipes for weight, activation, and KV-cache quantization targeting vLLM.
 - **llama.cpp** [the GGUF quantization ecosystem](https://github.com/ggml-org/llama.cpp): the reference for CPU, Metal, and consumer-hardware quantized inference.
+
+For the dense single-file reference (same material, interview-walkthrough shape):
+[topics/17-model-compression.md](../../topics/17-model-compression.md).

--- a/book/reasoning-serving/07-how-teams-do-it-in-production.md
+++ b/book/reasoning-serving/07-how-teams-do-it-in-production.md
@@ -45,3 +45,6 @@ cost per solved task.
 - **Google** [thinking in the Gemini API](https://ai.google.dev/gemini-api/docs/thinking): thinking budgets and how to turn them off for latency-sensitive calls.
 - **METR** [Measuring AI Ability to Complete Long Software Tasks](https://metr.org/blog/2025-03-19-measuring-ai-ability-to-complete-long-tasks/): capability expressed as the length of task a model completes, which is the demand side of the budget question.
 - **UIUC and collaborators** [Establishing Best Practices for Building Rigorous Agentic Benchmarks](https://arxiv.org/abs/2507.02825): how weak outcome validation inflates results, which is the same failure mode as a weak accept test in a cascade.
+
+For the dense single-file reference (same material, interview-walkthrough shape):
+[topics/18-reasoning-and-test-time-compute.md](../../topics/18-reasoning-and-test-time-compute.md).

--- a/topics/16-benchmark-evaluation.md
+++ b/topics/16-benchmark-evaluation.md
@@ -1,0 +1,274 @@
+# 16 - Benchmarking a model
+
+> **Interviewer:** "We are choosing between three candidate models and we also
+> fine-tuned our own. Walk me through the whole evaluation pipeline. How do you know
+> the numbers mean anything?"
+
+This is the model-level twin of [topic 06](06-evaluation-system.md). That one gates a
+*feature*; this one produces a defensible number for a *model*. The follow-ups are
+always the same three: why does your number differ from the published one, how do
+you know a 2-point gap is real, and how do you know the model has not already seen
+the test set. All three are systems questions, not metric questions.
+
+The book edition of this topic, with worked figures and a runnable statistics
+reference, is [book/benchmark-eval/](../book/benchmark-eval/).
+
+## 1. Clarify and scope
+
+- **What decision does the number drive?** Model selection, training telemetry, a
+  release gate, or an external claim. That sets the required rigor and the audience.
+- **Which capabilities matter?** Benchmark selection is where most of the error
+  comes from; a portfolio that does not match the workload measures the wrong thing
+  precisely.
+- **Open weights or API?** Decides whether log-probability scoring is available,
+  whether you can pin a revision, and whether you control the serving stack.
+- **Variable test-time compute?** If candidates have a thinking budget, quality is a
+  curve against spend, not a scalar, and a single number silently rewards whoever
+  thought longest.
+- **What difference must be resolvable?** "We need to call a 2-point gap" constrains
+  the design more than anything else, because it is a sample-size statement.
+
+## 2. Requirements
+
+**Functional.** Rank a mixed set of candidates on a capability portfolio; track our
+own checkpoints on the same protocol; produce numbers someone outside the team can
+reproduce.
+
+**Non-functional.** Resolve differences of about 2 points; control contamination;
+report cost alongside quality; complete a full grid overnight so it can run per
+candidate rather than per quarter.
+
+**Two consequences to state early.**
+
+1. **The score is an estimate produced by a protocol, so the protocol is part of the
+   result.** The reported artifact is a number, an interval, and a protocol hash
+   pinning harness commit, prompt template, model revision, decode parameters, and
+   sample count.
+2. **Published numbers are not comparable to yours, so re-run every baseline
+   yourself.** One harness, one protocol, all candidates, including the baseline you
+   think you already know.
+
+## 3. The pipeline
+
+```mermaid
+flowchart LR
+  SEL["benchmark portfolio<br/>(capability + headroom)"] --> ITEMS["pinned items<br/>(version, release dates)"]
+  ITEMS --> DECON["contamination control<br/>(time split, twins)"]
+  DECON --> RENDER["prompt render<br/>(chat template, few-shot,<br/>answer format)"]
+  RENDER --> GEN["generation<br/>(decode params, token budget,<br/>N samples, seeds)"]
+  GEN --> PARSE["extraction<br/>(parser / verifier / sandbox)"]
+  PARSE --> SCORE["scoring<br/>(exact, match, rubric, tests)"]
+  SCORE --> AGG["aggregate per slice<br/>with intervals"]
+  AGG --> CARD["report card<br/>score + CI + cost + hash"]
+  GEN -.-> STORE["run store: every prompt,<br/>completion, verdict"]
+  PARSE -.-> STORE
+```
+
+The stage nobody plans for is the run store. Keeping raw completions is what lets
+you re-score with a fixed parser instead of re-running the models, which separates a
+scoring change from a model change for free.
+
+## 4. Deep dives
+
+### The knobs that move the number more than the model does
+
+| Knob | Typical swing | What to do |
+|---|---|---|
+| Chat template, system prompt | Large, up to near-chance | Render from the model's own template; store the rendered string |
+| Few-shot count and order | Several points | Fix per benchmark; fix the shot pool by seed |
+| Scoring mode (log-likelihood vs generative) | Large | Choose per benchmark, report which, never mix across candidates |
+| Length normalization | Several points | Report which; keep identical across candidates |
+| Answer-format instruction and parser | Several points, one-directional | Standardize; measure the parse-failure rate |
+| Max output tokens | Very large on reasoning suites | Set from the observed length distribution; report truncation rate |
+| Temperature, samples, seeds | Double digits on small suites | One decode policy for all candidates; multiple seeds |
+| Serving stack, precision, provider | Enough to flip close calls | Pin engine version and container digest; provider is part of candidate identity |
+
+The canonical treatment is the LM Evaluation Harness maintainers' write-up, which
+documents prompt formatting alone moving a model between near-random and competent
+on the same items. The practical consequence: **when someone's number does not match
+yours, the prior is protocol difference, not model difference.**
+
+### Contamination
+
+Five kinds, and deduplication catches one: verbatim, near-duplicate, format leakage
+(the model learned the test's shape, nothing was duplicated), distillation from a
+contaminated teacher, and **selection leakage** (nothing entered training; you chose
+checkpoints by looking at the test set).
+
+Detection that you can actually run without the training corpus: score post-cutoff
+items against difficulty-matched pre-cutoff ones, use a time-gated benchmark
+(LiveBench, a LiveCodeBench release window), run membership-inference statistics
+such as Min-K% against a reference distribution of text the model could not have
+seen, and best of all build a **functional twin**, a benchmark rebuilt to the same
+spec with new items. A large drop on the twin is the contamination signature.
+
+Prevention: time-gated live benchmarks, a private internal set, procedurally
+generated items with a verifier, and a **sealed slice with a logged query budget**
+so selection leakage is bounded and auditable.
+
+### Item validity
+
+A leak-free benchmark still lies if the items are broken. Re-annotation of MMLU
+found a single-digit-percent error rate; adversarially filtered commonsense sets
+show similar problems; agentic benchmarks have been shown to accept incorrect
+solutions because their test suites are too weak. Cheap audits worth running: the
+no-question baseline for any multiple-choice set (anything meaningfully above chance
+is a red flag), and a manual review of 20 passing agent trajectories before
+publishing any agentic number.
+
+### Scoring
+
+Prefer executable checks, then answer matching, then rubrics, then judges.
+
+- **Answer matching** (free-form generation plus equivalence-aware comparison)
+  measures the same construct as multiple choice without the option-pattern
+  shortcut. Its equivalence step is a pipeline component with its own error rate,
+  and no comparison finer than that rate is supportable.
+- **Rubric grading** decomposes an open-ended judgment into per-item criteria with
+  weights, each nearly binary, which is what models and humans actually agree on.
+- **pass@k versus pass^k.** pass@k is coverage, the right metric when something
+  downstream verifies and selects. pass^k is reliability, all $k$ attempts
+  succeeding, and it decays geometrically: a 90 percent agent is about 43 percent at
+  $k=8$. Confusing them is the most common technical mistake in agent evaluation.
+
+### Certifying and correcting an autorater
+
+Once a model grades your benchmark it is part of the instrument. Certify it against
+a few hundred expert labels oversampled near the decision boundary, report agreement
+and swap consistency, probe it with degenerate inputs (empty, constant, padded, and
+an answer containing an instruction aimed at the grader), and pin its version.
+
+Then **correct rather than trust**. Prediction-powered inference keeps the cheap
+judge on all $N$ items and a human-labeled subset of size $n$, and rectifies:
+
+$$\hat{\theta}_{\text{PPI}} = \frac{1}{N}\sum_{i=1}^{N} f(X_i) + \frac{1}{n}\sum_{j=1}^{n}\bigl(Y_j - f(X_j)\bigr)$$
+
+The second term is an unbiased estimate of the judge's systematic error, so the
+result is unbiased regardless of judge quality, and a better judge buys a tighter
+interval rather than a different answer.
+
+### Statistics
+
+A score is an estimate: $\text{SE} = \sqrt{\hat p(1-\hat p)/n}$.
+
+| Items | Example | 95% half-width at $\hat p = 0.5$ |
+|---|---|---|
+| 30 | competition math sets | about 18 points |
+| 198 | GPQA Diamond | about 7 points |
+| 500 | SWE-bench Verified | about 4.4 points |
+| 2,000 | large aggregate suites | about 2.2 points |
+
+Compare **paired**: with $b$ items A wins and $c$ items B wins,
+$\hat\Delta = (b-c)/n$ and $\text{SE} \approx \sqrt{b+c}/n$, which is McNemar's
+test. Sizing follows: $n \gtrsim d \cdot 7.85/\delta^2$, so calling a 2-point gap at
+10 percent discordance needs on the order of 2,000 items. Add clustered errors for
+grouped items, multiple seeds on reasoning suites (single-run swings there routinely
+exceed the effect being claimed), and false-discovery control across a
+model-by-benchmark grid.
+
+Report cost with quality. Two effort settings of one model are two candidates, and
+the reportable unit is a point on a frontier: score, interval, output tokens,
+dollars, latency.
+
+## 5. Bottlenecks and scaling
+
+| Bottleneck | First sign | Fix |
+|---|---|---|
+| Agentic episode cost | The bill is dominated by a few suites | Cache on the protocol hash; stage a smoke subset before the full grid |
+| Provider rate limits | Wall clock, not compute, sets the runtime | Shard by item; run providers in parallel |
+| Stale cache after a template change | A null result that looks real | Key the cache on the full protocol hash plus item id plus sample index |
+| Container drift on code suites | Agentic scores move with no model change | Pin images by digest; log retry counts |
+| Small-suite noise | Rankings flip between runs | More seeds, report spread, retire saturated benchmarks |
+
+## 6. Failure modes
+
+- **A suspiciously good number** is contamination, a broken item, or a protocol bug
+  until proven otherwise.
+- **Truncation scored as failure**: a reasoning model cut off mid-derivation loses
+  points for a reason unrelated to ability.
+- **Selection leakage**: the reported number is a maximum over many looks.
+- **Judge bias in a headline number**: fine for ranking two candidates, wrong as an
+  absolute claim.
+- **An index that hides the movement**: normalize, weight explicitly, drop saturated
+  components, and bootstrap the rank, not just the score.
+
+## 7. Likely follow-ups
+
+- "Your number is 12 points below the model card. Debug it." Ordered checklist, then
+  re-run every candidate under your protocol.
+- "The new model is 3 points ahead on 400 items. Ship?" Compute it paired; be
+  willing to say not distinguishable and give the item count that would settle it.
+- "How do you evaluate a model that thinks?" Budget is part of candidate identity;
+  report a curve, track truncation, state the decode policy.
+- "We deduplicated the training data, so contamination is handled." Name the four
+  kinds dedup misses plus selection leakage, and offer a runnable black-box test.
+- "Can we just use MMLU?" Saturation, multiple-choice shortcuts, label errors.
+
+## Seen in production
+
+### The shared pipeline
+
+Pinned items, a standardized harness, raw outputs retained, and a report that
+carries its protocol. Everyone converges here; the divergence is in what they
+standardize and what they treat as the threat.
+
+### How they differ
+
+| System | Standardizes | Threat it designs against |
+|---|---|---|
+| LM Evaluation Harness (EleutherAI) | Prompt rendering and versioned task configs | Irreproducibility |
+| HELM (Stanford CRFM) | A multi-scenario, multi-metric reporting matrix | A single number misleading |
+| Inspect (UK AI Security Institute) | The agent loop and tool sandbox | Uncontrolled environments |
+| simple-evals (OpenAI) | Legible prompts and parsers | Protocols nobody can replicate |
+| HealthBench (OpenAI) | Per-item expert rubric criteria | Holistic scores that do not reproduce |
+| Anthropic eval-statistics practice | The analysis | Claiming gaps inside the noise |
+| LMArena | Human pairwise preference at scale | Task metrics missing aggregate taste |
+| LiveBench, LiveCodeBench | Item recency | Contamination |
+| METR | Task length with human baselines | Capability numbers with no business meaning |
+
+### The systems
+
+- **EleutherAI** [Lessons from the Trenches on Reproducible Evaluation of Language Models](https://arxiv.org/abs/2405.14782)
+- **Stanford CRFM** [HELM](https://crfm.stanford.edu/helm/)
+- **UK AI Security Institute** [Inspect](https://inspect.aisi.org.uk/)
+- **OpenAI** [simple-evals](https://github.com/openai/simple-evals) and [HealthBench](https://openai.com/index/healthbench/)
+- **Anthropic** [Adding Error Bars to Evals](https://arxiv.org/abs/2411.00640)
+- **Cohere Labs and collaborators** [The Leaderboard Illusion](https://arxiv.org/abs/2504.20879), with [LMArena's response](https://lmarena.ai/blog/our-response/)
+- **METR** [Measuring AI Ability to Complete Long Software Tasks](https://metr.org/blog/2025-03-19-measuring-ai-ability-to-complete-long-tasks/)
+- **LiveBench** [paper](https://arxiv.org/abs/2406.19314) and **LiveCodeBench** [paper](https://arxiv.org/abs/2403.07974)
+- **UIUC and collaborators** [Establishing Best Practices for Building Rigorous Agentic Benchmarks](https://arxiv.org/abs/2507.02825)
+- **Princeton NLP** [SWE-bench](https://arxiv.org/abs/2310.06770)
+- **Thinking Machines Lab** [Defeating Nondeterminism in LLM Inference](https://thinkingmachines.ai/blog/defeating-nondeterminism-in-llm-inference/)
+
+## Trace the architectures
+
+- **The model under test, at real dimensions (Llama 3 8B):**
+  [open it live](https://www.neurarch.com/?import=https://raw.githubusercontent.com/neurarch-ai/awesome-llm-model-zoo/main/architectures/llama3-8b/model.json).
+  Useful here because the protocol questions are architectural: which tokenizer and
+  chat template the harness must render, whether log-probability scoring is even
+  available, and how long a generation the KV budget supports before your
+  output-token cap starts truncating answers.
+
+  ![Llama 3 8B](https://raw.githubusercontent.com/neurarch-ai/awesome-llm-model-zoo/main/architectures/llama3-8b/assets/diagram.png)
+
+- **The autorater you would actually run (Qwen3-8B):**
+  [open it live](https://www.neurarch.com/?import=https://raw.githubusercontent.com/neurarch-ai/awesome-llm-model-zoo/main/architectures/qwen3-8b/model.json).
+  Trace its per-token cost, multiply by suite size times orderings times cadence,
+  and the grader stops being free infrastructure and becomes a budget line you can
+  size against the human-labeling budget that PPI trades it off with.
+
+  ![Qwen3-8B](https://raw.githubusercontent.com/neurarch-ai/awesome-llm-model-zoo/main/architectures/qwen3-8b/assets/diagram.png)
+
+These are validated reference graphs at real dimensions, shape-checked end to end,
+not screenshots. All 92 architectures live in the
+[Model Zoo](https://github.com/neurarch-ai/awesome-llm-model-zoo)
+([gallery](https://neurarch-ai.github.io/awesome-llm-model-zoo)). Built by
+[Neurarch](https://www.neurarch.com).
+
+## Related deep-dive drills
+
+Rapid-fire questions that probe the modeling and systems underneath this topic, from [deep-dives.md](../deep-dives.md):
+
+- [Decoding and sampling](../deep-dives.md#decoding-and-sampling)
+- [Training, fine-tuning, and overfitting](../deep-dives.md#training-fine-tuning-and-overfitting)
+- [Commonly asked, commonly missed](../deep-dives.md#commonly-asked-commonly-missed)

--- a/topics/17-model-compression.md
+++ b/topics/17-model-compression.md
@@ -1,0 +1,248 @@
+# 17 - Model compression
+
+> **Interviewer:** "This model is too big and too slow for where we need to run it.
+> Make it fit, and tell me what it costs us."
+
+There is a wrong answer that sounds right ("quantize to 4-bit, it is basically
+free") and a right answer that is three sentences longer: which resource is
+actually binding, which lever moves that resource on *your* hardware, and how you
+prove the quality you gave up is quality you can afford.
+
+The book edition, with worked figures and a runnable planner, is
+[book/model-compression/](../book/model-compression/).
+
+## 1. Clarify and scope
+
+- **What is binding?** A memory ceiling, decode latency, prefill or high-batch
+  throughput, and long-context cost are four different problems with four different
+  answers.
+- **What is the serving shape?** Batch one interactive or large batches. That
+  decides whether you are memory-bandwidth bound or compute bound.
+- **How long are the contexts?** Past a few thousand tokens the KV cache starts to
+  rival the weights, and compressing weights while ignoring KV solves the wrong half.
+- **Can we retrain?** Post-training only, a healing budget of billions of tokens, or
+  a real training run. This splits the method space in half.
+- **Which capabilities cannot move?** "No regression" is not a bar. Compression
+  damage is never uniform.
+- **What does the target accelerate?** int4 weight-only, fp8 compute, 2:4 sparsity,
+  and an on-device NPU's supported formats are four different answers.
+
+## 2. Requirements
+
+**Functional.** Fit the target, hold the named capabilities, and ship an artifact
+someone can serve with the runtime you actually deploy.
+
+**Non-functional.** Measured (not predicted) latency and memory on target hardware
+at production batch and context; a paired quality comparison against the
+uncompressed baseline; a rollback artifact kept warm.
+
+**Two consequences to state early.**
+
+1. **Compression is a hardware question wearing an algorithm's clothes.** A format
+   the accelerator does not accelerate is a memory technique, not a speed technique.
+2. **Top-line accuracy is the wrong acceptance test.** Compression scatters behavior
+   rather than shifting it, so two models can score the same and disagree on a large
+   fraction of items. Report a **flip rate**.
+
+## 3. Where the bytes and microseconds go
+
+$$\text{bytes} \approx \underbrace{N b_w}_{\text{weights}} + \underbrace{2 L h_{kv} d_h s B b_{kv}}_{\text{KV cache}} + \text{activations}$$
+
+- **Prefill** processes the prompt at once, reusing each weight across many tokens:
+  compute bound, time tracks FLOPs.
+- **Decode** produces one token at a time: memory-bandwidth bound, time tracks bytes
+  read, so halving weight bytes nearly halves decode latency at small batch.
+
+```mermaid
+flowchart TD
+  START["too big / slow / expensive"] --> Q{"what is binding?"}
+  Q -->|"memory ceiling"| MEM["quantize weights"]
+  Q -->|"decode latency"| DEC["quantize weights + KV"]
+  Q -->|"prefill / high batch"| PRE["low-precision compute (fp8)<br/>or fewer FLOPs"]
+  Q -->|"long context"| KV["GQA or MLA -> paged KV -> quantized KV"]
+  MEM --> GATE["acceptance test"]
+  DEC --> GATE
+  PRE --> GATE
+  KV --> GATE
+  GATE -->|"one capability regressed"| MIX["raise precision on the<br/>sensitive layers, re-test"]
+  MIX --> GATE
+  GATE -->|"still short"| SMALL["structured prune<br/>+ distill from the parent"]
+  SMALL --> GATE
+  GATE -->|"passes"| SHIP["ship as a new candidate model"]
+```
+
+## 4. Deep dives
+
+### Quantization
+
+Symmetric uniform quantization is
+$s = \max|w| / (2^{b-1}-1)$, $q = \text{round}(w/s)$, and everything interesting is
+in three choices: **what** you quantize (weights only, weights plus activations, or
+the KV cache), **granularity** (per tensor, per channel, or group-wise, which is what
+makes 4-bit viable and why "4-bit" is really about 4.125 bits at group 128), and
+**where the error goes**.
+
+The difficulty is outliers: a few activation channels carry values orders of
+magnitude larger than the rest and are functionally important, so a scale wide
+enough for them starves everything else. Four families of fix:
+
+| Family | Idea | Representative |
+|---|---|---|
+| Keep outliers high precision | Decompose the matmul | LLM.int8() |
+| Move the difficulty to weights | Per-channel scaling migrates outliers | SmoothQuant |
+| Protect salient weights | Scale channels chosen by activation magnitude | AWQ |
+| Compensate the error | Layer-wise second-order rounding | GPTQ |
+| Rotate outliers away | Orthogonal rotation, fused at export | QuaRot, SpinQuant |
+
+The rotation family is what unlocked 4-bit *activations* and KV, not just weights.
+For long contexts, quantize the cache asymmetrically (keys per channel, values per
+token), and remember the order of operations: architectural KV reduction (GQA, MLA)
+first, then paging, then quantization, then eviction or windowing last.
+
+**PTQ, QAT, and QLoRA are three different things.** PTQ produces a serving artifact
+in hours from a calibration set. QAT simulates the quantizer during training and is
+what you escalate to below 4 bits, usually with a distillation loss. QLoRA quantizes
+a base in order to fine-tune cheaply; it is not a serving quantization.
+
+### Pruning
+
+Whether removing weights buys anything depends on the *shape*:
+
+| Shape | Quality at 50 percent | Speed | Memory |
+|---|---|---|---|
+| Unstructured | Best | None on dense kernels | Only with sparse storage |
+| 2:4 semi-structured | Worse than unstructured | Real, on sparse tensor cores | About half |
+| Structured (heads, channels, layers) | Needs a healing run | Real everywhere | A genuinely smaller model |
+
+Selection criteria matter: magnitude alone is weak, and the activation-aware score
+$S_{ij} = |W_{ij}|\cdot\lVert X_j\rVert_2$ (Wanda) is competitive with
+reconstruction-based one-shot pruning (SparseGPT) at almost no cost. For structured
+pruning, width degrades gracefully while depth buys more latency per unit removed
+and damages multi-step behavior disproportionately. The production recipe when you
+have no pretraining budget: **prune the parent to the target shape, then distill the
+parent into it** (Sheared LLaMA, Minitron).
+
+### Distillation
+
+Soft targets carry the teacher's relative preferences over wrong answers, which is a
+far denser signal per token than hard labels. Offline (teacher-scored corpus),
+sequence-level, and on-policy (student generates, teacher scores) differ in whether
+the student ever sees its own mistakes; on-policy is strongest and makes the teacher
+part of your training infrastructure. Two side effects: a student distilled from
+long reasoning traces inherits their length, and it inherits the teacher's
+contamination, which no cleaning of your corpus can undo.
+
+### Serving a compressed model
+
+- **The win depends on batch size.** Weight-only quantization buys bandwidth, not
+  arithmetic: over 3x at batch one and closer to 1.15x at batch 64 for the same
+  change.
+- **Kernel support is the real constraint.** An unfused dequantize-then-matmul path
+  can be net slower. Assert the numeric path at startup, because several stacks fall
+  back to higher precision silently.
+- **Mixed precision by layer is the standard fix.** Embeddings, the output
+  projection, the first and last blocks, and norms stay higher; per-layer
+  sensitivity decides the rest.
+- **On-device is a different problem**: a hard memory ceiling shared with the OS, a
+  short list of fast formats, and batch one. The shipped pattern is a small distilled
+  student, quantized to the NPU's format, with task adapters over one resident base
+  and a server model for the rest.
+
+## 5. Bottlenecks and scaling
+
+| Bottleneck | First sign | Fix |
+|---|---|---|
+| Dequantization overhead | Quantized model slower than expected at low batch | Fused kernel for your shape and runtime |
+| Win evaporates at production batch | Great in the harness, flat in production | fp8 compute or a smaller model |
+| KV dominates at long context | Memory grows with traffic despite quantized weights | Quantized plus paged KV, or a GQA / MLA model |
+| One capability regressed | Average holds; JSON validity or long-context recall drops | Per-layer sensitivity, raise precision there |
+| Adapters degrade on the quantized base | Adapter works on fp16, not on int4 | Train or validate adapters against the served artifact |
+
+## 6. Failure modes
+
+- **Calibration set mismatched to serving traffic**: fine on public benchmarks,
+  degraded on your workload, and the public numbers exonerate the artifact.
+- **Silent precision fallback**: no speedup, no error, a confusing week.
+- **Sparsity quoted without a shape**: "50 percent pruned" that nobody can reproduce
+  as a speedup.
+- **Skipping the healing run** after structured pruning and blaming pruning.
+- **Composing levers without re-evaluating**: pruning and quantization damage the
+  same outlier-sensitive paths, so two levers that each cost a point can cost four.
+
+## 7. Likely follow-ups
+
+- "int4 is 4x cheaper, right?" Bytes yes, FLOPs no, and the win shrinks with batch.
+- "50 percent sparse is 2x faster?" Only if the shape is one the hardware can skip.
+- "Accuracy held, so it was free?" Report the flip rate.
+- "Can we PTQ to 2 bits since 1.58-bit models exist?" Those are trained that way.
+- "Which order: prune, distill, quantize?" Prune, heal or distill, then quantize,
+  and evaluate the composition.
+- "A compressed 70B or a native 8B?" Run both through the same acceptance test; the
+  third option (distill the parent into the small model) usually beats both.
+
+## Seen in production
+
+### The shared pipeline
+
+Pick the lever that moves the binding resource, keep a small set of layers at higher
+precision, and gate on a paired comparison against the uncompressed model.
+
+### How they differ
+
+| Approach | Primary constraint | Retraining |
+|---|---|---|
+| Weight-only int4 (GPTQ, AWQ lineage) | Fit and decode latency | None |
+| Activation and compute quantization (SmoothQuant, fp8) | Throughput per dollar | None to light |
+| Rotation-based low-bit (QuaRot, SpinQuant) | 4-bit activations and KV | None, or learned rotations |
+| Train-time ternary (BitNet) | Extreme efficiency | Full pretraining |
+| One-shot pruning (SparseGPT, Wanda) | Memory or a sparsity-accelerated target | None |
+| Prune plus distill (Minitron, Sheared LLaMA) | A size ladder from one parent | Billions of tokens |
+| On-device stacks (Apple Intelligence) | A hard device ceiling and fixed formats | Yes, in model design |
+| fp8 end to end (DeepSeek-V3) | Cost across the lifecycle | Designed in |
+
+### The systems
+
+- **LLM.int8()** [8-bit Matrix Multiplication for Transformers at Scale](https://arxiv.org/abs/2208.07339)
+- **SmoothQuant** [paper](https://arxiv.org/abs/2211.10438), **GPTQ** [paper](https://arxiv.org/abs/2210.17323), **AWQ** [paper](https://arxiv.org/abs/2306.00978)
+- **QuaRot** [paper](https://arxiv.org/abs/2404.00456) and **SpinQuant** [paper](https://arxiv.org/abs/2405.16406)
+- **Microsoft Research** [The Era of 1-bit LLMs](https://arxiv.org/abs/2402.17764)
+- **KIVI** [asymmetric 2-bit KV cache quantization](https://arxiv.org/abs/2402.02750)
+- **SparseGPT** [paper](https://arxiv.org/abs/2301.00774) and **Wanda** [paper](https://arxiv.org/abs/2306.11695)
+- **Princeton** [Sheared LLaMA](https://arxiv.org/abs/2310.06694), **NVIDIA** [Compact Language Models via Pruning and Knowledge Distillation](https://arxiv.org/abs/2407.14679)
+- **Google DeepMind** [On-Policy Distillation of Language Models](https://arxiv.org/abs/2306.13649)
+- **Apple** [Apple Intelligence Foundation Language Models](https://arxiv.org/abs/2407.21075)
+- **DeepSeek** [DeepSeek-V3 Technical Report](https://arxiv.org/abs/2412.19437)
+- **Microsoft Research India** [Accuracy is Not All You Need](https://arxiv.org/abs/2407.09141)
+- **Red Hat AI and vLLM** [llm-compressor](https://github.com/vllm-project/llm-compressor), **llama.cpp** [GGUF ecosystem](https://github.com/ggml-org/llama.cpp)
+
+## Trace the architectures
+
+- **A dense model where the arithmetic is concrete (Llama 3 8B):**
+  [open it live](https://www.neurarch.com/?import=https://raw.githubusercontent.com/neurarch-ai/awesome-llm-model-zoo/main/architectures/llama3-8b/model.json).
+  Read off layer count, KV head count, and head dimension, then plug them into the
+  weight and KV formulas above. That is the whole memory plan, and it is the fastest
+  way to see why a long context makes the cache rival the weights.
+
+  ![Llama 3 8B](https://raw.githubusercontent.com/neurarch-ai/awesome-llm-model-zoo/main/architectures/llama3-8b/assets/diagram.png)
+
+- **Where architecture beats compression (DeepSeek-V3):**
+  [open it live](https://www.neurarch.com/?import=https://raw.githubusercontent.com/neurarch-ai/awesome-llm-model-zoo/main/architectures/deepseek-v3/model.json).
+  Latent attention shrinks the KV cache structurally and the MoE layers mean most
+  parameters do not run per token, which is the point that compression is what you
+  do after the architecture is fixed.
+
+  ![DeepSeek-V3](https://raw.githubusercontent.com/neurarch-ai/awesome-llm-model-zoo/main/architectures/deepseek-v3/assets/diagram.png)
+
+These are validated reference graphs at real dimensions, shape-checked end to end,
+not screenshots. All 92 architectures live in the
+[Model Zoo](https://github.com/neurarch-ai/awesome-llm-model-zoo)
+([gallery](https://neurarch-ai.github.io/awesome-llm-model-zoo)). Built by
+[Neurarch](https://www.neurarch.com).
+
+## Related deep-dive drills
+
+Rapid-fire questions that probe the modeling and systems underneath this topic, from [deep-dives.md](../deep-dives.md):
+
+- [Distillation, pruning, and model compression](../deep-dives.md#distillation-pruning-and-model-compression)
+- [Inference, quantization, and serving math](../deep-dives.md#inference-quantization-and-serving-math)
+- [Scaling: rooflines, parallelism, and the arithmetic of large models](../deep-dives.md#scaling-rooflines-parallelism-and-the-arithmetic-of-large-models)

--- a/topics/18-reasoning-and-test-time-compute.md
+++ b/topics/18-reasoning-and-test-time-compute.md
@@ -1,0 +1,235 @@
+# 18 - Reasoning models and test-time compute
+
+> **Interviewer:** "We switched to a reasoning model. Quality went up, but p99
+> latency is unpredictable and the bill tripled. What do you do?"
+
+A model that thinks before answering turns output length from a roughly fixed cost
+into a heavy-tailed random variable, and every downstream property (latency tail, KV
+pressure, queueing, cost per request, autoscaling) inherits that tail. It is also an
+allocation problem: thinking is a quality axis you can buy per request, so the design
+question is not "reasoning on or off" but "which requests get how much."
+
+[Topic 05](05-post-training-pipeline.md) covers how these models are made (RLHF,
+GRPO, verifiable rewards). This one covers serving one. The book edition, with a
+runnable queueing and cost model, is [book/reasoning-serving/](../book/reasoning-serving/).
+
+## 1. Clarify and scope
+
+- **Is there a verifier?** Thinking pays off most where something can check the
+  answer, because parallel sampling is useless without a way to select.
+- **Is the latency budget a mean or a tail?** A p50 target and a p99 target are
+  almost different products once output length is a distribution.
+- **Does the user see the thinking?** A progress signal changes perceived latency
+  without changing the real one.
+- **Do we log outcomes per request?** Without "was it solved," you can compare
+  policies on price but not on value.
+- **Do we operate the fleet?** If so, thinking tokens hold KV slots and the queueing
+  behavior becomes your problem rather than the provider's.
+- **Is thinking actually better on this task?** It is not uniformly better, and the
+  comparison must be cost-matched.
+
+## 2. Requirements
+
+**Functional.** Serve a mixed workload under a latency promise, allocate a thinking
+budget per request, and account for whether each request was solved.
+
+**Non-functional.** Bound the tail, cap cost per request, and report **cost per
+solved task** alongside p95 or p99. Neither metric alone ranks a policy: cost per
+request is minimized by failing faster, accuracy by spending without limit.
+
+**Two consequences to state early.**
+
+1. **Output length is a random variable, so capacity planning moves from means to
+   tails.** Queueing delay depends on the second moment of service time.
+2. **Thinking is a purchasable quality axis, so the design is a router with a spend
+   dimension**, and the governing metric has a solved-task denominator.
+
+## 3. The decision flow
+
+```mermaid
+flowchart TD
+  REQ["request"] --> CLS{"how hard,<br/>and what does being<br/>wrong cost?"}
+  CLS -->|"easy / latency-sensitive"| SHORT["no thinking or small budget"]
+  CLS -->|"hard / high stakes"| LONG["large thinking budget"]
+  SHORT --> VER{"verifier<br/>accepts?"}
+  VER -->|"no"| ESC["escalate (quota-capped)"]
+  VER -->|"yes"| OUT["answer"]
+  ESC --> OUT
+  LONG --> CAP{"budget hit?"}
+  CAP -->|"yes"| FORCE["forced answer,<br/>never silent truncation"]
+  CAP -->|"no"| OUT
+  FORCE --> OUT
+  OUT --> ACCT["record tokens, latency,<br/>accepted, solved"]
+  ACCT -.->|"recalibrate"| CLS
+```
+
+## 4. Deep dives
+
+### Sequential versus parallel spend
+
+**Sequential** (one longer chain) needs no extra machinery and costs latency, since
+tokens are produced serially. **Parallel** (k samples) costs tokens and little
+latency, and is worthless without a selector: repeated sampling raises **coverage**,
+the chance that at least one sample is right, and only a verifier converts that into
+delivered quality. Allocating adaptively by difficulty beats a fixed setting.
+
+Where thinking does not help: factual recall (the fix is retrieval), formatting and
+extraction (shallow mappings, and long chains add drift), latency-bound interactive
+surfaces, and anything with no checkable signal and no rubric.
+
+### The tail
+
+For service time $S$ at utilization $\rho$, queueing delay grows as
+
+$$E[W] = \frac{\rho}{1-\rho} \cdot \frac{E[S]\,(1 + C^{2})}{2}, \qquad C^{2} = \frac{\text{Var}(S)}{E[S]^{2}}$$
+
+so two workloads with the same mean and different tails have very different p99s,
+and the thinking workload always has the fatter tail. On top of the queueing effect
+there is a structural one: long generations hold KV slots, the effective batch
+collapses, and short requests queue behind them (head-of-line blocking).
+
+Controls, in the order to reach for them: a **hard budget cap** with a **forced
+answer** at the boundary (silent truncation returns malformed output and evaluates as
+a wrong answer), **separate queues by budget class**, **length prediction** to
+restore approximate shortest-job-first, **preemption** at scale, and **admission
+control** that downgrades rather than queues under overload.
+
+### Allocation
+
+Three policies, and the arithmetic that chooses between them:
+
+$$C_{\text{cascade}} = c_{\text{short}} + c_{\text{verify}} + (1-a)\,c_{\text{long}} \quad\text{beats}\quad c_{\text{long}} \iff a \gt \frac{c_{\text{short}} + c_{\text{verify}}}{c_{\text{long}}}$$
+
+At a short path around a tenth the cost of the long one, the threshold is near 15
+percent: if the cheap path handles even one request in five, cascading wins. And a
+cascade has a property the others do not, since escalated requests effectively get
+two attempts, so its solve rate can **exceed** always-thinking.
+
+A cheap attempt plus a verifier is also a better difficulty classifier than any
+difficulty classifier, because it measures what you care about rather than
+predicting it. Use prediction when there is no verifier or when escalation latency
+is unacceptable. Model routing composes with budget routing, and the underrated cell
+is a small model given room to think with a verifier to catch its mistakes.
+
+### Verification
+
+| Verifier | Signal | Gameable |
+|---|---|---|
+| Execution (tests, compiler, SQL run) | Ground truth on the tested behavior | Only by overfitting the tests |
+| Symbolic or schema check | Exact, for the property checked | Rarely |
+| Self-consistency (majority vote) | Agreement, not correctness | Cannot distinguish confident wrongness |
+| Outcome reward model | Learned score on the answer | Yes, the classic reward-hacking target |
+| Process reward model | Score per step | Yes, more subtly |
+| Rubric judge | A model's opinion | Yes: verbosity, self-preference, injection |
+
+Delivered quality is coverage times selector accuracy, so a 0.98 coverage with a 0.6
+selector delivers about 0.6: **pass@k is what you can buy, the verifier decides how
+much you keep.** Best-of-n against a learned reward is optimization *against* the
+verifier, which is why quality can peak and then fall as k grows.
+
+### Serving
+
+Continuous batching matters more and delivers less (slot turnover is the scarce
+resource). Prefix caching helps the prompt, not the unique trace. Speculative
+decoding attacks exactly the right phase, since thinking is pure bandwidth-bound
+decode. Disaggregating prefill and decode becomes more attractive as the decode
+phase lengthens. Capacity planning carries three numbers: $E[S]$, $C^2$, and the
+budget-cap hit rate.
+
+## 5. Bottlenecks and scaling
+
+| Bottleneck | First sign | Fix |
+|---|---|---|
+| Slots held by long generations | Effective batch far below configured | Budget caps, budget-class queues, preemption |
+| p99 blowup at moderate load | Mean fine, tail terrible | Lower utilization, separate queues, predict length |
+| KV pressure from traces | Preemption or OOM under load | Paged and quantized KV, shorter budgets |
+| Verification cost exceeds generation | Cost per solved task rises even as quality does | Cheaper verifier, verify only escalations |
+| Escalation storm | Traffic shifts, the long path saturates | Cap the escalation rate; shed or downgrade |
+| No outcome logging | Policies cannot be compared at all | Log solved-or-not before optimizing anything |
+
+## 6. Failure modes
+
+- **Silent truncation at the budget cap** returns malformed answers and scores as
+  wrong reasoning.
+- **Cost per request as the headline**: minimized by failing faster.
+- **pass@k quoted as reliability**: the user gets one attempt, so the metric is
+  pass^k, and a 90 percent agent is about 43 percent at $k=8$.
+- **Uncertified judge as the accept test**: converts a quality problem into a silent
+  one.
+- **Benchmarking a reasoning model against a non-reasoning one on score alone**: the
+  comparison must be cost-matched.
+
+## 7. Likely follow-ups
+
+- "Why did p99 get so much worse than the mean?" Second moment plus head-of-line
+  blocking.
+- "How do you set the budget?" The measured accuracy-versus-budget curve, capped at
+  the knee, with the cap-hit rate monitored.
+- "Best-of-16 is worse than best-of-4. How?" Optimization pressure against an
+  imperfect verifier.
+- "How do you schedule without knowing job length?" Predict a length class or
+  partition by budget class; FIFO is optimal for nothing here.
+- "Just add GPUs?" The most expensive lever, because variance forces you far below
+  saturation.
+
+## Seen in production
+
+### The shared pipeline
+
+A budget knob, a policy that decides who gets how much, and something that tells you
+whether the answer was right.
+
+### How they differ
+
+| Approach | Budget control | Selection | Watch out |
+|---|---|---|---|
+| Provider effort parameter | An effort or thinking-token setting | None built in | Little visibility into the tail |
+| Self-hosted with a scheduler | Hard caps plus queue policy | Whatever you build | Real serving engineering |
+| Prompt-level budget forcing | Suppress or inject the end-of-thinking marker | Usually self-consistency | Forcing a budget the model was not trained for degrades output |
+| Best-of-n with an executor | Fixed k, parallel | Tests, compiler, SQL | Sandbox capacity; weak tests accept wrong answers |
+| Cascade with a checker | Cheap path then escalate | Executor or certified judge | Escalation storms |
+| Process-supervised selection | Fixed k, parallel | Step-level reward model | Verification can cost more than generation |
+
+### The systems
+
+- **DeepSeek** [DeepSeek-R1](https://arxiv.org/abs/2501.12948)
+- **Stanford and collaborators** [s1: Simple test-time scaling](https://arxiv.org/abs/2501.19393)
+- **Google DeepMind and UC Berkeley** [Scaling LLM Test-Time Compute Optimally](https://arxiv.org/abs/2408.03314)
+- **Stanford** [Large Language Monkeys](https://arxiv.org/abs/2407.21787)
+- **OpenAI** [Let's Verify Step by Step](https://arxiv.org/abs/2305.20050) and the [reasoning guide](https://platform.openai.com/docs/guides/reasoning)
+- **Anthropic** [extended thinking](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking)
+- **Google** [thinking in the Gemini API](https://ai.google.dev/gemini-api/docs/thinking)
+- **METR** [Measuring AI Ability to Complete Long Software Tasks](https://metr.org/blog/2025-03-19-measuring-ai-ability-to-complete-long-tasks/)
+- **UIUC and collaborators** [Establishing Best Practices for Building Rigorous Agentic Benchmarks](https://arxiv.org/abs/2507.02825)
+
+## Trace the architectures
+
+- **A reasoning-capable open model (Qwen3-8B):**
+  [open it live](https://www.neurarch.com/?import=https://raw.githubusercontent.com/neurarch-ai/awesome-llm-model-zoo/main/architectures/qwen3-8b/model.json).
+  Its KV geometry is what turns a 10,000-token thinking trace into occupied memory:
+  multiply layers by KV heads by head dimension to get bytes per token, then by the
+  budget you were about to grant, and the slot-occupancy problem becomes a number.
+
+  ![Qwen3-8B](https://raw.githubusercontent.com/neurarch-ai/awesome-llm-model-zoo/main/architectures/qwen3-8b/assets/diagram.png)
+
+- **Where the architecture makes long thinking affordable (DeepSeek-V3):**
+  [open it live](https://www.neurarch.com/?import=https://raw.githubusercontent.com/neurarch-ai/awesome-llm-model-zoo/main/architectures/deepseek-v3/model.json).
+  Latent attention compresses the KV cache structurally and sparse expert routing
+  keeps per-token compute down, which is why the architecture family behind the
+  open reasoning models looks the way it does.
+
+  ![DeepSeek-V3](https://raw.githubusercontent.com/neurarch-ai/awesome-llm-model-zoo/main/architectures/deepseek-v3/assets/diagram.png)
+
+These are validated reference graphs at real dimensions, shape-checked end to end,
+not screenshots. All 92 architectures live in the
+[Model Zoo](https://github.com/neurarch-ai/awesome-llm-model-zoo)
+([gallery](https://neurarch-ai.github.io/awesome-llm-model-zoo)). Built by
+[Neurarch](https://www.neurarch.com).
+
+## Related deep-dive drills
+
+Rapid-fire questions that probe the modeling and systems underneath this topic, from [deep-dives.md](../deep-dives.md):
+
+- [Reasoning and test-time compute](../deep-dives.md#reasoning-and-test-time-compute)
+- [Decoding and sampling](../deep-dives.md#decoding-and-sampling)
+- [Inference, quantization, and serving math](../deep-dives.md#inference-quantization-and-serving-math)

--- a/topics/README.md
+++ b/topics/README.md
@@ -30,6 +30,8 @@ navigate by use case instead, start from the
 - [02 - Long-context inference and the KV cache](02-long-context-and-kv-cache.md)
 - [04 - LLM inference serving at scale](04-inference-serving-at-scale.md)
 - [11 - Cost optimization and model routing](11-cost-optimization-and-model-routing.md)
+- [17 - Model compression](17-model-compression.md)
+- [18 - Reasoning models and test-time compute](18-reasoning-and-test-time-compute.md)
 - [10 - Realtime streaming chat](10-realtime-streaming-chat.md)
 
 **Retrieval and knowledge**
@@ -42,6 +44,7 @@ navigate by use case instead, start from the
 
 **Quality and safety**
 - [06 - LLM evaluation system](06-evaluation-system.md)
+- [16 - Benchmarking a model](16-benchmark-evaluation.md)
 - [07 - Safety, moderation, and guardrails](07-safety-and-guardrails.md)
 - [12 - Production monitoring and observability](12-production-monitoring-and-observability.md)
 
@@ -49,7 +52,6 @@ navigate by use case instead, start from the
 
 - Speculative decoding deep dive and disaggregated prefill/decode
 - Cost modeling and capacity planning end to end
-- On-device and edge LLM serving
 
 ## Contributing a topic
 


### PR DESCRIPTION
Follow-up to the merged chapter PRs. Those three chapters were book-only, so the repo root, the topics index, and the question bank had no route to them.

Adds the dense single-file counterparts in the `topics/` walkthrough shape (interviewer question, clarify and scope, requirements, the flow, deep dives, bottlenecks, failure modes, likely follow-ups, seen in production, live architectures, deep-dive drills):

- `topics/16-benchmark-evaluation.md`
- `topics/17-model-compression.md`
- `topics/18-reasoning-and-test-time-compute.md`

Registers all three in `topics/README.md` and the root README tables (the "Book-only chapters" stopgap section is removed), and cross-links each book chapter's production section to its topic counterpart and back.

Gates: `validate-book` 214 files clean, all 19 capstones pass, `check-links` 321 URLs with 0 dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)