### PR TITLE
Borrow from the big awesome lists: a site, a paper list, a dataset list, a contribution template, and the topics they exposed as missing

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,6 +1,6 @@
 name: Check external links
 
-# Runs monthly (and on demand) to catch link rot in book/ citations.
+# Runs monthly (and on demand) to catch link rot in book/ and papers.md citations.
 # Not part of the push/PR gate: external sites rate-limit and bot-block, which would
 # make a required check flaky. Fails only on genuinely DEAD links (404 / DNS / TLS).
 on:
@@ -16,5 +16,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "24"
-      - name: Check external links in book/
+      - name: Check external links in book/ and papers.md
         run: node tools/check-links.mjs

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,54 @@
+name: Build and deploy site
+
+# Publishes the same markdown as a browsable site with a sidebar and search:
+# https://neurarch-ai.github.io/awesome-llm-system-design/
+#
+# One-time setup in the repository: Settings > Pages > Source = GitHub Actions.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# A queued deploy should wait for the running one rather than cancel it, so main
+# never ends up published from an older commit than the one that finished last.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install mkdocs
+        run: pip install -r tools/requirements-site.txt
+      - name: Stage content and write the mkdocs config
+        run: node tools/build-site.mjs
+      - name: Build
+        run: mkdocs build -f .site/mkdocs.yml
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .site/out
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.site/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,11 @@ Thanks for improving this book. A few house rules keep every chapter rendering
 correctly on GitHub and reading consistently. CI runs the validator on every push
 and pull request, so please run it locally before opening a PR.
 
+**Writing something new rather than fixing something?** Start from
+[**template/**](template/): a skeleton for a topic walkthrough and one for a full
+book chapter, plus the list of places a new file has to be registered before anything
+links to it. This page is what CI rejects; that one is what to write.
+
 ## Before you push
 
 ```bash
@@ -77,8 +82,12 @@ that the translation is now behind.
 
 ## Chapter structure
 
+Copy [`template/chapter/`](template/chapter/) rather than an existing chapter: it
+carries the fixed section positions and the guidance for each, and its capstone block
+already runs under the gate.
+
 Chapters live in `book/<slug>/` as one file per section (`01-clarifying-requirements`
-through `09-summary`, plus a `README.md` index). A chapter opens with a
+through `10-putting-it-together`, plus a `README.md` index). A chapter opens with a
 Candidate/Interviewer dialogue to scope the problem, walks the design end to end, and
 closes with a production section (with first-party links), an interview Q&A, and a
 summary. Figures are worked matplotlib PNGs in `assets/` and mermaid diagrams. Keep

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ numbers change. More on why that matters [below](#about-the-diagrams).
 > zero-dependency reference you can execute with nothing but Python 3.
 > 中文读者：这本书有官方中文版，在 [**book-zh/**](book-zh/)，和英文版逐章对应。
 
+> **Want a sidebar and a search box?** The same material is published as a site at
+> **[neurarch-ai.github.io/awesome-llm-system-design](https://neurarch-ai.github.io/awesome-llm-system-design/)**,
+> generated from these exact files. Searching there covers all 490 pages at once,
+> including the Chinese edition, which is the fastest way to find the one paragraph
+> that answers a question you are stuck on.
+
 ---
 
 ## How to use this repo

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ can.
 
 ## License
 
-MIT. See [LICENSE](LICENSE). Contributions welcome; see
-[topics/README.md](topics/README.md).
+MIT. See [LICENSE](LICENSE). Contributions welcome: [CONTRIBUTING.md](CONTRIBUTING.md)
+for the house rules, [template/](template/) for a skeleton to start from.
 
 Built and maintained by the team behind [Neurarch](https://www.neurarch.com).

--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ All eighteen topics are written and ready.
 bank of ~206 rapid-fire, depth-probing questions: the follow-ups an interviewer
 pulls once the design is on the board (normalization and attention variants, where KL divergence shows up, optimization and gradient descent, decoding and sampling, generative model families, distributed-training failure modes, and quantization tradeoffs). Each answer leads with the mechanism, then the tradeoff.
 
+**The papers an interviewer assumes you have read** are collected per topic in
+[**papers.md**](papers.md), eight at most for each, with one line on what each
+changes for you. The cap is the point: a list of everything is an index of a field,
+not a study plan. The 128 papers the walkthroughs already cite are in there, next to
+the canon they take for granted.
+
 See [topics/README.md](topics/README.md) for the full roadmap and how to
 contribute a topic.
 

--- a/papers.md
+++ b/papers.md
@@ -1,0 +1,472 @@
+# Papers, by topic
+
+The repo's [production case studies](CASE-STUDIES.md) answer "how did a real team
+ship this." This page answers the other half: **which papers does an interviewer
+assume you have read** before they ask a follow-up.
+
+Every topic caps at eight. That cap is the point. A list of two thousand papers is
+an index of a field, not a study plan, and nobody reads one before a loop. These are
+the ones whose result gets referenced by name in an interview: "that is the GQA
+tradeoff", "that is the Chinchilla point", "that is what SelfCheckGPT does."
+
+**How to read this page.** For each entry, the sentence after the year is the thing
+to be able to say about it. If you can produce that sentence and the number attached
+to it, you have gotten what an interview will ask for. Read the abstract and the one
+figure that carries the result; read the whole paper only for the topics you are
+being hired to own.
+
+A paper appears under two topics when both interviews genuinely assume it. That
+repetition is deliberate: this is a study list per topic, not a bibliography.
+
+Not on this page: engineering blog posts and first-party writeups. Those are the
+**Seen in production** section of every topic, rolled up in
+[CASE-STUDIES.md](CASE-STUDIES.md) (with per-system
+[teardowns](CASE-TEARDOWNS.md)), and for several topics they carry more of the real
+answer than the papers do.
+
+---
+
+## Start here
+
+The five an interviewer will not stop to explain, in any LLM loop, for any role.
+
+- **[Attention Is All You Need](https://arxiv.org/abs/1706.03762)** (2017). The
+  transformer. You need it for the shapes: what Q, K and V are, why the KV cache is
+  a thing at all, and where the quadratic term in prefill comes from.
+- **[Language Models are Few-Shot Learners](https://arxiv.org/abs/2005.14165)**
+  (2020). GPT-3. In-context learning as the reason prompting is a design surface
+  rather than a hack, and the first serious "just scale it" result.
+- **[Scaling Laws for Neural Language Models](https://arxiv.org/abs/2001.08361)**
+  (2020). Loss is a power law in compute, data and parameters. This is the paper
+  that makes "how big should the model be" a calculation instead of an opinion.
+- **[Training Compute-Optimal Large Language Models](https://arxiv.org/abs/2203.15556)**
+  (2022). Chinchilla. Corrects the previous one: most models of that era were far
+  too big for their token budget. The 20-tokens-per-parameter rule of thumb comes
+  from here, and interviewers still use it as a sanity check.
+- **[Training language models to follow instructions with human feedback](https://arxiv.org/abs/2203.02155)**
+  (2022). InstructGPT. Why a base model is not a product, and the SFT then reward
+  model then PPO shape that every post-training pipeline is still a variant of.
+
+One more if you have time: **[The Llama 3 Herd of Models](https://arxiv.org/abs/2407.21783)**
+(2024), which is the most complete public description of an end-to-end modern build,
+data through post-training through serving, and useful as a reference answer for
+almost any "how would you actually do this" question.
+
+---
+
+## Building and adapting the model
+
+### [The LLM training lifecycle](topics/13-llm-lifecycle.md) · [book chapter](book/llm-lifecycle/)
+
+- **[The Llama 3 Herd of Models](https://arxiv.org/abs/2407.21783)** (2024). The
+  whole lifecycle in one paper, with the numbers: data mix, compute, parallelism,
+  post-training stages, and the serving decisions at the end.
+- **[DeepSeek-V3 Technical Report](https://arxiv.org/abs/2412.19437)** (2024). The
+  cost-conscious counterpart: MoE plus MLA plus FP8 training, and an explicit
+  training-cost figure, which is why it comes up whenever "could a small team do
+  this" is the question.
+- **[Tulu 3](https://arxiv.org/abs/2411.15124)** (2024). Fully open post-training
+  recipe, including the eval suite and the decontamination, so it is the citable
+  answer for what a modern SFT plus preference-tuning stack contains.
+- **[DeepSeek-R1](https://arxiv.org/abs/2501.12948)** (2025). Reasoning ability
+  from RL with verifiable rewards, and the reason "post-training" now includes a
+  stage that did not exist in the InstructGPT picture.
+- **[Scaling Laws for Neural Language Models](https://arxiv.org/abs/2001.08361)**
+  (2020) and **[Chinchilla](https://arxiv.org/abs/2203.15556)** (2022). The budget
+  arithmetic that decides what stage you are even allowed to be in.
+
+### [Data curation and pretraining](topics/14-data-curation-and-pretraining.md) · [book chapter](book/data-and-pretraining/)
+
+- **[Exploring the Limits of Transfer Learning (C4)](https://arxiv.org/abs/1910.10683)**
+  (2019). The original filtered web corpus, and the source of the heuristic filters
+  everyone still starts from.
+- **[Deduplicating Training Data Makes Language Models Better](https://arxiv.org/abs/2107.06499)**
+  (2021). Near-duplicate removal improves the model and cuts memorization. This is
+  the paper to name when asked why dedup is a pipeline stage rather than a nicety.
+- **[The RefinedWeb Dataset for Falcon LLM](https://arxiv.org/abs/2306.01116)**
+  (2023). Web data only, properly filtered, beats curated corpora. It settles the
+  "do we need books and code" question with an experiment.
+- **[The FineWeb Datasets](https://arxiv.org/abs/2406.17557)** (2024). The current
+  reference for how filtering decisions are actually ablated, one at a time, with
+  the eval that justified each.
+- **[DataComp-LM](https://arxiv.org/abs/2406.11794)** (2024). Fixes the model and
+  varies the data, which is the experiment design an interviewer wants when you
+  claim a data change helped.
+- **[Megatron-LM](https://arxiv.org/abs/1909.08053)** (2019) and
+  **[ZeRO](https://arxiv.org/abs/1910.02054)** (2019). Tensor parallelism and the
+  optimizer-state sharding that make the memory arithmetic work. Between them they
+  cover most of what "how do you shard a 70B train" is asking.
+- **[Textbooks Are All You Need](https://arxiv.org/abs/2306.11644)** (2023). Data
+  quality substituting for scale, and the case for synthetic data with its caveats
+  attached.
+- **[Tensor Programs V (muP)](https://arxiv.org/abs/2203.03466)** (2022). Tune
+  hyperparameters on a small model and transfer them. The answer to "you cannot
+  afford to sweep learning rates at that scale."
+
+### [Mid-training: continued pretraining and long context](topics/15-continued-pretraining-and-long-context.md) · [book chapter](book/mid-training/)
+
+- **[RoFormer (RoPE)](https://arxiv.org/abs/2104.09864)** (2021). Rotary position
+  embeddings. Every context-extension trick below is a modification of this, so it
+  is the prerequisite, not optional background.
+- **[Extending Context Window via Position Interpolation](https://arxiv.org/abs/2306.15595)**
+  (2023). The first cheap extension: squeeze positions into the trained range. Know
+  why it works and what it costs at short context.
+- **[YaRN](https://arxiv.org/abs/2309.00071)** (2023). The interpolation method
+  actually used in production, per-frequency rather than uniform.
+- **[LongRoPE](https://arxiv.org/abs/2402.13753)** (2024). Search over the rescaling
+  factors, to 2M tokens, plus the recovery training that keeps short-context quality.
+- **[Don't Stop Pretraining](https://arxiv.org/abs/2004.10964)** (2020). Domain and
+  task adaptive pretraining. Still the cleanest evidence for "continue pretraining
+  before you fine-tune."
+- **[Simple and Scalable Strategies to Continually Pre-train LLMs](https://arxiv.org/abs/2403.08763)**
+  (2024). Learning-rate re-warming plus a replay fraction, which is the concrete
+  answer to catastrophic forgetting.
+- **[DoReMi](https://arxiv.org/abs/2305.10429)** (2023). Domain weights optimized
+  rather than guessed, the mechanism behind mixture reweighting.
+- **[RULER](https://arxiv.org/abs/2404.06654)** (2024). Claimed context length
+  versus usable context length. Bring this one when someone quotes a 1M window.
+
+### [Fine-tuning and post-training](topics/05-post-training-pipeline.md) · [book chapter](book/post-training/)
+
+- **[LoRA](https://arxiv.org/abs/2106.09685)** (2021). Low-rank adapters. The
+  parameter and memory arithmetic here is the most commonly asked back-of-envelope
+  in the whole post-training topic.
+- **[QLoRA](https://arxiv.org/abs/2305.14314)** (2023). 4-bit base plus adapters,
+  which is what makes "fine-tune a 65B on one GPU" a real answer rather than a wish.
+- **[Direct Preference Optimization](https://arxiv.org/abs/2305.18290)** (2023).
+  Preference tuning without a separate reward model or RL loop. Be able to say what
+  it gives up relative to PPO, not just that it is simpler.
+- **[Constitutional AI](https://arxiv.org/abs/2212.08073)** (2022). Preference labels
+  from a written policy instead of from people, and the origin of RLAIF.
+- **[Tulu 3](https://arxiv.org/abs/2411.15124)** (2024). The full open recipe, with
+  the eval gates and decontamination that a real pipeline needs and most answers skip.
+- **[Llama 2](https://arxiv.org/abs/2307.09288)** (2023). Still the most detailed
+  public account of iterative RLHF with two reward models, useful for the "how many
+  rounds, and what breaks" follow-up.
+
+---
+
+## Inference and serving
+
+### [Long-context inference and the KV cache](topics/02-long-context-and-kv-cache.md) · [book chapter](book/kv-cache/)
+
+- **[FlashAttention](https://arxiv.org/abs/2205.14135)** (2022). Attention is
+  memory-bound, not compute-bound. This reframing is the foundation of the whole
+  cost model, and the reason tiling beats a smarter algorithm.
+- **[GQA](https://arxiv.org/abs/2305.13245)** (2023). Grouped-query attention. The
+  single most asked "shrink the cache" lever, and the quality-versus-memory tradeoff
+  you should be able to quantify.
+- **[Efficient Memory Management with PagedAttention](https://arxiv.org/abs/2309.06180)**
+  (2023). vLLM. Fragmentation as the real reason batch sizes were small, solved with
+  a page table. Expect to be asked to explain it as if it were virtual memory.
+- **[DeepSeek-V2](https://arxiv.org/abs/2405.04434)** (2024). Multi-head latent
+  attention: compress the cache instead of sharing heads. The current alternative to
+  GQA, so knowing both is what separates a current answer from a 2023 one.
+- **[Efficient Streaming LMs with Attention Sinks](https://arxiv.org/abs/2309.17453)**
+  (2023). Why dropping the first tokens destroys quality, and the fix. The best
+  single paper on what a sliding window actually breaks.
+- **[H2O: Heavy-Hitter Oracle](https://arxiv.org/abs/2306.14048)** (2023). Evicting
+  KV entries by attention mass, the reference point for every cache-eviction policy.
+- **[SnapKV](https://arxiv.org/abs/2404.14469)** (2024). Compress the prompt's cache
+  at prefill using the attention the prompt itself produces.
+- **[KIVI](https://arxiv.org/abs/2402.02750)** (2024). 2-bit KV quantization, tuning
+  free, and the per-channel versus per-token asymmetry that makes it work.
+
+### [LLM inference serving at scale](topics/04-inference-serving-at-scale.md) · [book chapter](book/inference-serving/)
+
+- **[Fast Inference from Transformers via Speculative Decoding](https://arxiv.org/abs/2211.17192)**
+  (2022). A draft model proposes, the target verifies, and the output distribution
+  is unchanged. That last clause is the part interviews test.
+- **[Medusa](https://arxiv.org/abs/2401.10774)** (2024). Extra decoding heads instead
+  of a second model, which removes the "where do I get a draft model" problem.
+- **[EAGLE](https://arxiv.org/abs/2401.15077)** (2024). Speculate in feature space,
+  currently the strongest acceptance rates. Know why feature-level beats token-level.
+- **[Sarathi-Serve](https://arxiv.org/abs/2403.02310)** (2024). Chunked prefill:
+  the throughput-versus-latency knob, and how prefill stalls decode in one batch.
+- **[Splitwise](https://arxiv.org/abs/2311.18677)** (2023) and
+  **[DistServe](https://arxiv.org/abs/2401.09670)** (2024). Prefill and decode have
+  different bottlenecks, so run them on different machines. The clearest statement of
+  disaggregation, which is where serving architecture went.
+- **[Mooncake](https://arxiv.org/abs/2407.00079)** (2024). A KV-cache-centric
+  cluster: the cache, not the GPU, as the thing you schedule around.
+- **[SGLang](https://arxiv.org/abs/2312.07104)** (2023). RadixAttention, prefix
+  sharing across requests. The right answer to "many requests share a system prompt."
+
+### [Cost optimization and model routing](topics/11-cost-optimization-and-model-routing.md) · [book chapter](book/cost-optimization/)
+
+- **[FrugalGPT](https://arxiv.org/abs/2305.05176)** (2023). Cascades and routing,
+  with the cost-versus-quality frontier drawn explicitly. The reference for "use the
+  cheap model first" as an engineered policy rather than a vibe.
+- **[RouteLLM](https://arxiv.org/abs/2406.18665)** (2024). Train the router on
+  preference data, and evaluate it as a router. Note what it needs: labelled
+  preferences you probably do not have on day one.
+- **[Mixtral of Experts](https://arxiv.org/abs/2401.04088)** (2024). Sparse MoE:
+  active parameters versus total parameters, which is the distinction that makes an
+  MoE cost estimate right or wrong.
+- **[Chatbot Arena](https://arxiv.org/abs/2403.04132)** (2024). Where the quality
+  number a router optimizes against comes from, and how noisy it is.
+
+Most of the evidence for this topic is operational rather than academic. The
+routing, caching and right-sizing writeups in
+[CASE-STUDIES.md](CASE-STUDIES.md) carry more of the real answer than the papers.
+
+### [Model compression](topics/17-model-compression.md) · [book chapter](book/model-compression/)
+
+- **[LLM.int8()](https://arxiv.org/abs/2208.07339)** (2022). Outlier features are
+  why naive quantization collapses. This is the paper that defines the problem the
+  rest of the list is solving.
+- **[GPTQ](https://arxiv.org/abs/2210.17323)** (2022). One-shot weight quantization
+  to 3 and 4 bits with second-order information.
+- **[AWQ](https://arxiv.org/abs/2306.00978)** (2023). Protect the salient weight
+  channels, identified from activations. The most-deployed weight-only method.
+- **[SmoothQuant](https://arxiv.org/abs/2211.10438)** (2022). Migrate activation
+  outliers into the weights so both sides can be 8-bit, which is what makes W8A8
+  serving practical.
+- **[SparseGPT](https://arxiv.org/abs/2301.00774)** (2023) and
+  **[Wanda](https://arxiv.org/abs/2306.11695)** (2023). One-shot pruning, and then
+  the same result with a far simpler criterion. Read both: the second is the reason
+  to be suspicious of complexity in this area.
+- **[Sheared LLaMA](https://arxiv.org/abs/2310.06694)** (2023) and
+  **[Minitron](https://arxiv.org/abs/2407.14679)** (2024). Structured pruning plus
+  continued training, which is the only pruning shape hardware actually rewards.
+- **[The Era of 1-bit LLMs](https://arxiv.org/abs/2402.17764)** (2024). BitNet
+  b1.58. Know it as the frontier, and know it needs training from scratch.
+- **[Accuracy is Not All You Need](https://arxiv.org/abs/2407.09141)** (2024). Two
+  models with equal benchmark accuracy can disagree on half their answers. The
+  paper to cite when someone accepts a compressed model on one aggregate number.
+
+### [Reasoning and test-time compute](topics/18-reasoning-and-test-time-compute.md) · [book chapter](book/reasoning-serving/)
+
+- **[Chain-of-Thought Prompting](https://arxiv.org/abs/2201.11903)** (2022). Where
+  test-time compute as a lever starts.
+- **[Self-Consistency](https://arxiv.org/abs/2203.11171)** (2022). Sample many, take
+  the majority. The cheapest version of "spend more at inference", and the baseline
+  any fancier method has to beat.
+- **[Tree of Thoughts](https://arxiv.org/abs/2305.10601)** (2023). Search over
+  reasoning states. Mostly useful now as the cost cautionary tale.
+- **[Let's Verify Step by Step](https://arxiv.org/abs/2305.20050)** (2023). Process
+  supervision beats outcome supervision. The origin of the verifier in modern
+  reasoning stacks.
+- **[Large Language Monkeys](https://arxiv.org/abs/2407.21787)** (2024). Coverage
+  scales with samples, but only if you can pick the right one. The pass@k versus
+  pass^k distinction lives here.
+- **[Scaling LLM Test-Time Compute Optimally](https://arxiv.org/abs/2408.03314)**
+  (2024). When extra inference compute beats a bigger model, and when it does not.
+- **[s1: Simple test-time scaling](https://arxiv.org/abs/2501.19393)** (2025).
+  Budget forcing with 1k examples. The "you can do this cheaply" data point.
+- **[DeepSeek-R1](https://arxiv.org/abs/2501.12948)** (2025). RL with verifiable
+  rewards, and what a long thinking trace does to your serving cost model.
+
+### [Realtime streaming chat](topics/10-realtime-streaming-chat.md) · [book chapter](book/streaming-chat/)
+
+- **[Efficient Streaming LMs with Attention Sinks](https://arxiv.org/abs/2309.17453)**
+  (2023). What breaks in an endless conversation, and the minimal fix.
+- **[Whisper](https://arxiv.org/abs/2212.04356)** (2022). The ASR half of a voice
+  pipeline, and where its latency actually goes.
+- **[Moshi](https://arxiv.org/abs/2410.00037)** (2024). Full-duplex speech-text, the
+  paper to name when asked how to remove turn-taking latency instead of shaving it.
+
+This topic is mostly a transport and backpressure problem, so the
+[production writeups](CASE-STUDIES.md) matter more here than the literature does.
+
+---
+
+## Retrieval and knowledge
+
+### [RAG serving](topics/01-rag-serving.md) · [book chapter](book/rag-serving/)
+
+- **[Retrieval-Augmented Generation for Knowledge-Intensive NLP](https://arxiv.org/abs/2005.11401)**
+  (2020). The original. Worth reading for how much of the current stack was already
+  there, and which part (the trained retriever) mostly was not adopted.
+- **[Dense Passage Retrieval](https://arxiv.org/abs/2004.04906)** (2020). Dual
+  encoders beating BM25, and the in-batch negatives trick that made it trainable.
+- **[Lost in the Middle](https://arxiv.org/abs/2307.03172)** (2023). Position in the
+  context window changes whether the model uses a passage. The single best argument
+  for re-ranking and for a small k.
+- **[HyDE](https://arxiv.org/abs/2212.10496)** (2022). Generate a hypothetical
+  answer, embed that. The cheapest fix for query-document vocabulary mismatch.
+- **[Self-RAG](https://arxiv.org/abs/2310.11511)** (2023). Retrieve on demand and
+  critique what came back, rather than retrieving unconditionally.
+- **[Ragas](https://arxiv.org/abs/2309.15217)** (2023). Reference-free RAG metrics
+  (faithfulness, answer and context relevance). Know the definitions; you will be
+  asked how to evaluate this without labels.
+- **[GraphRAG](https://arxiv.org/abs/2404.16130)** (2024). For global questions no
+  single chunk answers. Also read it for the cost, which is the usual reason not to.
+- **[RAGO](https://arxiv.org/abs/2503.14649)** (2025). RAG serving as a scheduling
+  and placement problem, which is the systems half the other papers skip.
+
+### [Semantic search and embedding services](topics/08-semantic-search-and-embeddings.md) · [book chapter](book/semantic-search/)
+
+- **[HNSW](https://arxiv.org/abs/1603.09320)** (2016). The index almost everything
+  uses. Recall versus latency versus memory is tuned with the parameters in this
+  paper, so know what ef and M do.
+- **[ColBERT](https://arxiv.org/abs/2004.12832)** (2020). Late interaction: better
+  quality than a single vector, at a storage cost you should be able to estimate.
+- **[MTEB](https://arxiv.org/abs/2210.07316)** (2022). How embedding models are
+  compared, and why a leaderboard rank does not transfer to your corpus.
+- **[E5: Text Embeddings by Weakly-Supervised Contrastive Pre-training](https://arxiv.org/abs/2212.03533)**
+  (2022). The recipe behind the open embedding models you would actually deploy.
+- **[Embedding-based Retrieval in Facebook Search](https://arxiv.org/abs/2006.11632)**
+  (2020). The first end-to-end production account: serving, hybrid retrieval, and
+  the deployment problems that only appear at scale.
+- **[Applying Embedding-Based Retrieval to Airbnb Search](https://arxiv.org/abs/2601.06873)**
+  (2026) and **[Scaling Multilingual Semantic Search in Uber Eats](https://arxiv.org/abs/2603.06586)**
+  (2026). Two recent first-party systems, useful because they report what they
+  traded away, which papers usually do not.
+
+---
+
+## Building applications
+
+### [Agent orchestration](topics/03-agent-orchestration.md) · [book chapter](book/agents/)
+
+- **[ReAct](https://arxiv.org/abs/2210.03629)** (2022). Interleave reasoning and
+  acting. The loop every agent framework is still running.
+- **[Toolformer](https://arxiv.org/abs/2302.04761)** (2023). Tool use learned rather
+  than prompted, and a useful contrast with today's fine-tuned tool-calling APIs.
+- **[Reflexion](https://arxiv.org/abs/2303.11366)** (2023). Verbal self-critique in
+  an episodic memory. Know it, and know the cost it adds per task.
+- **[AutoGen](https://arxiv.org/abs/2308.08155)** (2023). Multi-agent conversation
+  as a programming model. The reference for "should this be one agent or several",
+  where the defensible answer is usually one.
+- **[Voyager](https://arxiv.org/abs/2305.16291)** (2023). A skill library that grows,
+  which is the cleanest example of agent memory that is not just a vector store.
+- **[SWE-bench](https://arxiv.org/abs/2310.06770)** (2023). The benchmark that made
+  agent claims falsifiable. Expect the "why is this hard to score" follow-up.
+- **[tau-bench](https://arxiv.org/abs/2406.12045)** (2024). Tool-agent-user
+  interaction with a simulated user, and pass^k as the reliability metric. This is
+  the number to quote when asked whether an agent is production-ready.
+- **[Measuring AI Ability to Complete Long Software Tasks](https://arxiv.org/abs/2503.14499)**
+  (2025). Task length as the axis of difficulty, which reframes "what can an agent
+  do" as "for how long can it stay on track."
+
+### [Multimodal serving](topics/09-multimodal-serving.md) · [book chapter](book/multimodal/)
+
+- **[CLIP](https://arxiv.org/abs/2103.00020)** (2021). Contrastive image-text
+  pretraining. The encoder half of most VLMs, and the source of the shared space.
+- **[ViT](https://arxiv.org/abs/2010.11929)** (2020). Images as patch tokens. Read it
+  for the token-count arithmetic: patch size decides your serving cost.
+- **[Flamingo](https://arxiv.org/abs/2204.14198)** (2022). Cross-attention into a
+  frozen LLM, the first of the two architectural families.
+- **[BLIP-2](https://arxiv.org/abs/2301.12597)** (2023). A small trained bridge
+  between a frozen encoder and a frozen LLM: the cheapest way to build one.
+- **[LLaVA](https://arxiv.org/abs/2304.08485)** (2023). A linear projector and
+  instruction tuning. The second family, and the default starting point.
+- **[MM1](https://arxiv.org/abs/2403.09611)** (2024). Ablations over the design
+  choices, so it is the paper to cite for why a choice is made rather than just what.
+- **[Qwen2-VL](https://arxiv.org/abs/2409.12191)** (2024). Native dynamic
+  resolution: variable image tokens, and the batching problem that creates.
+- **[Chameleon](https://arxiv.org/abs/2405.09818)** (2024). Early fusion, one token
+  stream. The architecture to name when asked what comes after the projector.
+
+---
+
+## Quality and safety
+
+### [LLM evaluation system](topics/06-evaluation-system.md) · [book chapter](book/evaluation/)
+
+- **[Judging LLM-as-a-Judge with MT-Bench and Chatbot Arena](https://arxiv.org/abs/2306.05685)**
+  (2023). Establishes both that judges agree with humans at roughly human-human
+  rates, and the biases (position, verbosity, self-preference) you must control for.
+- **[Judging the Judges](https://arxiv.org/abs/2406.12624)** (2024). The failure
+  modes measured. Read it before proposing an LLM judge as a regression gate.
+- **[JudgeBench](https://arxiv.org/abs/2410.12784)** (2024). Judges evaluated on
+  objectively checkable pairs, which is how you would validate your own.
+- **[Stratified Prediction-Powered Inference](https://arxiv.org/abs/2406.04291)**
+  (2024). Combine a few human labels with many model labels and keep a valid
+  confidence interval. The rigorous answer to "we cannot label everything."
+- **[How to Correctly Report LLM-as-a-Judge Evaluations](https://arxiv.org/abs/2511.21140)**
+  (2025). What the error bar on a judged eval actually has to include.
+- **[HealthBench](https://arxiv.org/abs/2505.08775)** (2025). Physician-written
+  rubrics at scale: the best public model of a domain eval built with experts.
+
+### [Benchmarking a model](topics/16-benchmark-evaluation.md) · [book chapter](book/benchmark-eval/)
+
+- **[MMLU](https://arxiv.org/abs/2009.03300)** (2020) and
+  **[HELM](https://arxiv.org/abs/2211.09110)** (2022). The benchmark everyone quotes,
+  and the framework that argued a single number was never enough.
+- **[Chatbot Arena](https://arxiv.org/abs/2403.04132)** (2024). Pairwise human
+  preference with Elo, and its sampling and identifiability problems.
+- **[The Leaderboard Illusion](https://arxiv.org/abs/2504.20879)** (2025). How
+  private variants and selective reporting distort a public board. The strongest
+  available answer to "why not just trust the leaderboard."
+- **[Adding Error Bars to Evals](https://arxiv.org/abs/2411.00640)** (2024). The
+  paper to have read before reporting any eval number at all.
+- **[A Careful Examination of LLM Performance on Grade School Arithmetic](https://arxiv.org/abs/2405.00332)**
+  (2024). GSM1k: a fresh copy of GSM8k exposes contamination as a measurable gap.
+- **[LiveBench](https://arxiv.org/abs/2406.19314)** (2024) and
+  **[LiveCodeBench](https://arxiv.org/abs/2403.07974)** (2024). Contamination
+  handled by construction, with continuously refreshed questions.
+- **[Establishing Best Practices for Building Rigorous Agentic Benchmarks](https://arxiv.org/abs/2507.02825)**
+  (2025). Task validity and outcome validity, and how many agent benchmarks fail them.
+
+### [Safety, moderation, and guardrails](topics/07-safety-and-guardrails.md) · [book chapter](book/safety/)
+
+- **[Constitutional AI](https://arxiv.org/abs/2212.08073)** (2022). Safety from a
+  written policy the model applies to itself, which is also how a policy becomes
+  auditable.
+- **[Llama Guard](https://arxiv.org/abs/2312.06674)** (2023). A dedicated
+  input-output classifier with a taxonomy, the standard shape of a guardrail model.
+- **[ShieldGemma](https://arxiv.org/abs/2407.21772)** (2024). The same idea at
+  several sizes, so it is the paper for the latency-versus-accuracy tradeoff on the
+  filter itself.
+- **[Universal and Transferable Adversarial Attacks](https://arxiv.org/abs/2307.15043)**
+  (2023). GCG. Automated, transferable jailbreak suffixes. This is why "we tested
+  some prompts" is not a defense.
+- **[Ignore Previous Prompt](https://arxiv.org/abs/2211.09527)** (2022). Prompt
+  injection stated plainly, and still the clearest framing of why data in the
+  context window is untrusted input.
+- **[NeMo Guardrails](https://arxiv.org/abs/2310.10501)** (2023). Programmable
+  rails as a system component, useful for what a policy-routing layer looks like.
+- **[TruthfulQA](https://arxiv.org/abs/2109.07958)** (2021). Models imitate human
+  falsehoods, and scale alone makes it worse. Good grounding for the difference
+  between safety and correctness.
+
+### [Production monitoring and observability](topics/12-production-monitoring-and-observability.md) · [book chapter](book/monitoring/)
+
+- **[SelfCheckGPT](https://arxiv.org/abs/2303.08896)** (2023). Sample several
+  responses and measure their consistency. The reference method for flagging
+  hallucinations online with no labels and no ground truth.
+- **[How is ChatGPT's behavior changing over time?](https://arxiv.org/abs/2307.09009)**
+  (2023). A model you do not control drifts under you. The paper to cite for why a
+  regression suite runs on a schedule and not only on your own releases.
+- **[Stratified Prediction-Powered Inference](https://arxiv.org/abs/2406.04291)**
+  (2024). Online quality estimates from a small human-labelled slice, with a valid
+  interval attached.
+
+This topic is thinner in the literature than the others on purpose: tracing,
+sampling and alerting are engineering, and the
+[production writeups](CASE-STUDIES.md) are the better source.
+
+---
+
+## Frontier
+
+### [World models and embodied agents](book/world-models/)
+
+- **[World Models](https://arxiv.org/abs/1803.10122)** (2018). Learn a compressed
+  model of the environment, then train the policy inside it. The framing everything
+  here inherits.
+- **[MuZero](https://arxiv.org/abs/1911.08265)** (2019). Planning with a learned
+  model that never has to reconstruct observations, only what matters for the value.
+- **[DreamerV3](https://arxiv.org/abs/2301.04104)** (2023). One configuration across
+  many domains, which is what made learned-model RL look like an engineering choice.
+- **[GAIA-1](https://arxiv.org/abs/2309.17080)** (2023). A generative world model for
+  driving, and the clearest example of the video-prediction-as-simulator argument.
+- **[Genie](https://arxiv.org/abs/2402.15391)** (2024). Interactive environments
+  learned from video with no action labels.
+- **[OpenVLA](https://arxiv.org/abs/2406.09246)** (2024). An open vision-language
+  action model, the concrete artifact behind "a VLM that outputs robot actions."
+- **[V-JEPA 2](https://arxiv.org/abs/2506.09985)** (2025). Prediction in
+  representation space rather than pixel space, plus zero-shot robot planning.
+- **[WorldArena](https://arxiv.org/abs/2602.08971)** (2026). Evaluating perception
+  against functional utility, which is the measurement problem this whole area has.
+
+---
+
+## Contributing to this page
+
+Add a paper only with the sentence that says what it changes for the reader, and
+only where a topic has fewer than eight. If a topic is full, the honest move is to
+argue for a swap in the pull request rather than to make the list longer. See
+[CONTRIBUTING.md](CONTRIBUTING.md).

--- a/template/README.md
+++ b/template/README.md
@@ -1,0 +1,86 @@
+# Templates
+
+[CONTRIBUTING.md](../CONTRIBUTING.md) says what CI rejects. This folder says what to
+write in the first place: copy a skeleton, fill it in, delete the guidance comments.
+
+| You want to add | Copy | To |
+|---|---|---|
+| An interview walkthrough of a system we do not cover | [`topic.md`](topic.md) | `topics/NN-your-slug.md` |
+| A full teaching chapter (10 sections, figures, capstone) | [`chapter/`](chapter/) | `book/your-slug/` |
+| A paper to an existing topic's reading list | nothing | `papers.md` |
+| A production system to an existing topic | nothing | that topic's `## Seen in production`, then `node tools/build.mjs` |
+
+A topic is roughly 400 to 900 lines and can be written in one sitting. A chapter is
+ten files and a capstone that has to execute. If you are unsure, write the topic:
+several chapters started that way.
+
+---
+
+## What actually gets a change merged here
+
+The house rules in CONTRIBUTING are mechanical and CI checks them. These four are the
+editorial ones, and they are what reviews here are about:
+
+1. **A claim carries a number or a first-party link.** "GQA saves memory" is not a
+   contribution. "GQA with 8 groups cuts the cache by 8x at roughly 1 percent
+   quality loss, [paper]" is. If neither a number nor a source exists, say the thing
+   is not measured rather than asserting it.
+2. **`## Seen in production` takes first-party engineering writeups only.** The
+   company's own blog, paper, or talk. Not a summary, not a newsletter, not a
+   vendor page about someone else's system. A link that requires a login is out.
+3. **Say what a technique costs, in the same breath as what it buys.** Every method
+   in here has a tradeoff, and an answer that lists only benefits is the answer that
+   fails an interview. This is the single most common reason a draft needs another pass.
+4. **Do not invent an interviewer dialogue that resolves too easily.** In section 01
+   each question either removes work or changes the design. A question whose answer
+   changes nothing is filler and should be cut.
+
+## Before you open the pull request
+
+```bash
+node tools/validate-book.mjs   # required if you touched book/ or book-zh/
+python3 tools/run-capstones.py # required if you touched a 10-putting-it-together.md
+node tools/build.mjs           # required if you touched a Seen in production section
+node tools/check-links.mjs     # optional, slow, catches a dead citation before a reviewer does
+```
+
+To read your draft the way the site will render it (sidebar, search, math, mermaid):
+
+```bash
+pip install -r tools/requirements-site.txt
+node tools/build-site.mjs && mkdocs serve -f .site/mkdocs.yml
+```
+
+## Registering a new topic or chapter
+
+Nothing scans the filesystem for content, so a new file that is not listed anywhere
+is invisible. Add it in these places:
+
+**A new topic** (`topics/NN-your-slug.md`):
+
+- the table in the root [README.md](../README.md) under the right pipeline stage
+- the list in [topics/README.md](../topics/README.md)
+- at least one question in [questions.md](../questions.md) that routes to it
+- `csOrder` and `tdOrder` in [tools/build.mjs](../tools/build.mjs), plus
+  `tools/comparisons/NN.md` and `tools/teardowns/NN.md`, if it has case studies
+- a reading list section in [papers.md](../papers.md)
+
+**A new chapter** (`book/your-slug/`):
+
+- the chapter table in [book/README.md](../book/README.md), under one of its `###`
+  group headings. This is load-bearing beyond the README: the site's sidebar reads
+  the chapter order and grouping out of that table, so a chapter missing from it is
+  a chapter missing from the navigation.
+- [book/reading-paths.md](../book/reading-paths.md), if it belongs to one of the paths
+
+The Chinese edition in `book-zh/` mirrors `book/` file for file. A translation is
+welcome but not required: open the English chapter, and say in the pull request that
+`book-zh/your-slug/` is still missing so it can be picked up.
+
+## Adding a paper to papers.md
+
+One line saying what the paper changes for the reader, not what it is about. Every
+topic is capped at eight, and the cap is the page's whole editorial position. If the
+topic you want to add to is full, propose a swap in the pull request and say which
+entry earns its place less. Check the arXiv id resolves to the title you wrote; a
+wrong id is the one error nobody catches by reading.

--- a/template/chapter/01-clarifying-requirements.md
+++ b/template/chapter/01-clarifying-requirements.md
@@ -1,0 +1,47 @@
+# 1. Clarifying the requirements
+
+<!--
+  Four to eight exchanges. The rule that makes this section worth reading: every
+  question either removes work or fundamentally changes the design. A question whose
+  answer changes nothing is filler, and a reviewer will ask you to cut it.
+
+  The answers you write here are the chapter's fixed numbers. Every later section
+  computes against them, so pick values you are willing to do arithmetic with.
+-->
+
+Before designing anything, pin down what the system must do. Here is a typical
+exchange between a candidate and an interviewer. Notice that every question either
+removes work or fundamentally changes the design.
+
+---
+
+**Candidate:** The first question, the one whose answer decides the architecture
+rather than a parameter?
+
+**Interviewer:** The answer, specific enough to design against, with a number in it.
+
+---
+
+**Candidate:** The scale question. How much, how fast, how many?
+
+**Interviewer:** The numbers the rest of the chapter will use.
+
+---
+
+**Candidate:** The constraint question. Budget, latency, hardware, or a policy
+boundary?
+
+**Interviewer:** The constraint, stated as a hard limit.
+
+---
+
+## What we are building
+
+One paragraph restating the problem with every answer folded in, so a reader who
+skipped the dialogue can still follow the chapter.
+
+**Requirements**
+
+- Functional: ...
+- Non-functional, with numbers: ...
+- Explicitly out of scope: ...

--- a/template/chapter/02-frame-the-system.md
+++ b/template/chapter/02-frame-the-system.md
@@ -1,0 +1,44 @@
+# 2. Framing the system
+
+<!--
+  This is the section that prevents the rest of the chapter from being a list of
+  techniques. Establish the cost model, the invariant, or the taxonomy that every
+  later section refers back to. If sections 03 to 06 do not point at something
+  introduced here, this section is not doing its job.
+-->
+
+## What this actually is
+
+Define the thing, and say what it is not. Compare it against the neighbouring idea
+readers confuse it with, in a table.
+
+| | This | The thing it gets confused with |
+|---|---|---|
+| Decides what at runtime | | |
+| Fails how | | |
+| Costs what | | |
+
+## The cost model
+
+The one piece of arithmetic the whole chapter derives from, with units and a worked
+number, not just symbols.
+
+$$
+\text{total} = \text{term}_1 + \text{term}_2
+$$
+
+Worked once, with the numbers from section 1, so the reader sees the magnitude:
+
+- term 1: ... = X
+- term 2: ... = Y
+- total: Z, which is the number every later section is trying to move.
+
+## The shape of a design
+
+```mermaid
+flowchart LR
+  A[Stage] --> B[Stage]
+  B --> C[Stage]
+```
+
+Name the levers. Each of sections 03 to 06 takes one and goes deep on it.

--- a/template/chapter/03-first-deep-dive.md
+++ b/template/chapter/03-first-deep-dive.md
@@ -1,0 +1,38 @@
+# 3. The first deep dive
+
+<!--
+  Rename the file and the heading to the mechanism. Sections 03 to 06 all take this
+  shape; four of them is typical, three is fine, more than five means the chapter
+  should be two chapters.
+
+  Number them in the H1 (3., 4., ...) to match the file prefix. The site and the
+  README both order by filename, so the two must agree.
+-->
+
+The question this section answers, in one sentence.
+
+## How it works
+
+The mechanism, in the fewest words that still let a reader reconstruct it. One
+figure, referenced as `assets/fig-name.png`, or one mermaid diagram.
+
+## The arithmetic
+
+$$
+\text{quantity} = \ldots
+$$
+
+Then the same formula with the chapter's numbers substituted in, and the result
+stated in the unit a reader cares about (dollars, milliseconds, gigabytes).
+
+## When to use which
+
+| Method | Use when | Cost | Do not use when |
+|---|---|---|---|
+| | | | |
+
+## What it costs
+
+Every technique in this book has a price. State it here explicitly, in the same
+terms as the benefit. A section that lists only benefits is the answer that fails
+an interview.

--- a/template/chapter/07-how-teams-do-it-in-production.md
+++ b/template/chapter/07-how-teams-do-it-in-production.md
@@ -1,0 +1,30 @@
+# 7. How teams do it in production
+
+<!--
+  First-party engineering writeups only: the company's own blog, paper, or talk.
+  Not a summary, not a newsletter, not a vendor page about someone else's system.
+
+  If this chapter has a matching topics/NN file, its `## Seen in production`
+  section is the same list, and tools/build.mjs reads that one into the case
+  indexes. Keep the two consistent.
+-->
+
+What the writeups below have in common, in two or three sentences. Then the more
+useful half: where they disagree, and what decision made them disagree.
+
+## Where the real designs diverge
+
+```mermaid
+flowchart TD
+  Q{The decision} -->|constraint A| X[Company X's answer]
+  Q -->|constraint B| Y[Company Y's answer]
+```
+
+| Team | Chose | Because | Gave up |
+|---|---|---|---|
+| | | | |
+
+## The systems (first-party links)
+
+- **Company** [Title of the writeup](https://example.com) - what it illustrates, and
+  the one number worth remembering from it.

--- a/template/chapter/08-interview-qa.md
+++ b/template/chapter/08-interview-qa.md
@@ -1,0 +1,29 @@
+# 8. Interview Q&A
+
+<!--
+  Three subsections, in this order. The third is the one readers come back for, so
+  do not skip it: name the answer that sounds right and say why it is wrong.
+-->
+
+## Commonly asked
+
+**Q: ...**
+
+The answer, leading with the mechanism, then the tradeoff. Two to six sentences. If
+a number makes it concrete, use the number.
+
+## Tricky (the follow-ups that separate candidates)
+
+**Q: ...**
+
+The answer, including the part most candidates miss.
+
+## Commonly answered wrong (the traps)
+
+**Q: ...**
+
+**The tempting answer:** what most people say.
+
+**Why it is wrong:** the mechanism that makes it wrong, not just an assertion.
+
+**What to say instead:** ...

--- a/template/chapter/09-summary.md
+++ b/template/chapter/09-summary.md
@@ -1,0 +1,33 @@
+# 9. Summary
+
+## One-page recap
+
+The chapter compressed to what you would want in front of you ten minutes before an
+interview. Bullets, each with the number attached.
+
+## The system on one page
+
+```mermaid
+flowchart LR
+  A[Input] --> B[Component] --> C[Output]
+```
+
+## Test yourself
+
+<!--
+  Questions with answers, not questions alone. A reader working through this
+  offline has nobody to check against.
+-->
+
+**1.** A question that requires computing something from the chapter's cost model.
+
+<details><summary>Answer</summary>
+
+The worked answer, with the arithmetic shown.
+
+</details>
+
+## Further reading
+
+- [Paper title](https://arxiv.org/abs/XXXX.XXXXX) - what it changes for you. Add it
+  to [papers.md](../../papers.md) too if the topic there is not already at eight.

--- a/template/chapter/10-putting-it-together.md
+++ b/template/chapter/10-putting-it-together.md
@@ -1,0 +1,56 @@
+# 10. Putting it together: the complete build
+
+<!--
+  Every chapter ends here, and this file is gated: tools/run-capstones.py extracts
+  the FIRST python code block and executes it with python3 and no packages installed.
+  Standard library only, deterministic, under 60 seconds, exit code 0.
+
+  Four parts, in this order: the default, the build, the same build under different
+  constraints, and the runnable reference.
+-->
+
+## The default stack: start here, deviate with reason
+
+For a first system with no unusual constraint, this is the answer, and the reason
+each piece is in it.
+
+| Layer | Default choice | Why | When to deviate |
+|---|---|---|---|
+| | | | |
+
+## The complete build
+
+The chapter's scenario, built end to end, with the sizing and dollar arithmetic
+carried through. Not a diagram: the numbers, in order, until a total.
+
+## The same techniques under different constraints
+
+Re-derive the same system twice more. Two contrasting constraint sets, each changing
+at least one major decision.
+
+| | Default | Constraint set A | Constraint set B |
+|---|---|---|---|
+| Decision | | | |
+| Cost | | | |
+
+## What each constraint decides
+
+One paragraph per constraint on which decision it flips, so a reader can map their
+own situation onto one of the three.
+
+## The smallest runnable reference
+
+Standard library only. It should be the smallest program that makes the chapter's
+central mechanism observable, and its output should be worth reading.
+
+```python
+"""One-paragraph docstring: what this demonstrates, and what to look at in the output."""
+
+
+def main() -> None:
+    print("replace me with the chapter's mechanism, in the standard library only")
+
+
+if __name__ == "__main__":
+    main()
+```

--- a/template/chapter/README.md
+++ b/template/chapter/README.md
@@ -1,0 +1,51 @@
+# Chapter Title
+
+<!--
+  Copy this folder to book/your-slug/ and delete every HTML comment.
+  Then add the chapter to the table in book/README.md under one of its ### group
+  headings: that table is what the site's sidebar is generated from, so a chapter
+  missing from it is a chapter with no navigation.
+
+  Files: 01, 02, then your own 03 to 06, then 07, 08, 09, 10 as named here. The
+  fixed positions are the point. A reader who has finished one chapter knows where
+  the production writeups and the interview questions are in every other one.
+-->
+
+> **Style note.** Keep or rewrite this note. It exists so a reader knows what kind
+> of document they are in: teach-first, one idea per figure, an interviewer dialogue
+> to open, and a cost model that the rest of the chapter derives from.
+
+An interviewer rarely says "explain X." They say **"..."**, the symptom-first version
+of the question. Open with that sentence, then name the one entry point that makes
+the rest of the chapter follow: the quantity, the cost model, or the constraint every
+later section refers back to.
+
+## Sections
+
+1. [Clarifying the requirements](01-clarifying-requirements.md) -- the dialogue that scopes the problem.
+2. [Framing the system](02-frame-the-system.md) -- what this thing is, and the shape of a design.
+3. [Your first deep dive](03-first-deep-dive.md) -- the mechanism the chapter is really about.
+4. ... -- sections 04 to 06 are yours to name, same shape as 03.
+5. ...
+6. ...
+7. [How teams do it in production](07-how-teams-do-it-in-production.md) -- named companies, divergence table, first-party links.
+8. [Interview Q&A](08-interview-qa.md) -- commonly asked, tricky, and commonly answered wrong.
+9. [Summary](09-summary.md) -- one-page recap, mermaid, test-yourself, further reading.
+10. [Putting it together: the complete build](10-putting-it-together.md) -- the default stack, the scenario costed end to end, the same system under two other constraint sets, and a runnable reference.
+
+## The whole system on one page
+
+```mermaid
+flowchart LR
+  A[Input] --> B[The component this chapter is about]
+  B --> C[Output]
+  L[A lever] -.what it changes.-> B
+```
+
+Read the sections in order the first time. They build on each other. Each opens with
+the question an interviewer actually asks, then answers it.
+
+<!--
+  Figures go in this folder's assets/ and are referenced as assets/fig-name.png.
+  Every image reference must resolve to a file that exists, and CI checks it.
+-->

--- a/template/topic.md
+++ b/template/topic.md
@@ -1,0 +1,123 @@
+# NN - Topic title
+
+<!--
+  Copy to topics/NN-your-slug.md, then delete every HTML comment in this file.
+  NN is the next free two-digit number; keep it in the filename and the H1.
+  Target length is 400 to 900 lines. Nine sections, in this order, no others:
+  an interviewer follows this arc, and the repo's value is that every topic
+  answers in the same shape.
+-->
+
+**The question, as an interviewer poses it:** "..."
+
+<!--
+  Write it the way it is actually said out loud, symptom first: "our GPU bills are
+  climbing and p99 is bad under load, walk me through it." Not "explain the KV
+  cache." The whole topic is the answer to this one sentence.
+-->
+
+One paragraph on what makes this question hard, and the entry point that makes the
+rest of the answer follow. Name the one quantity everything else derives from.
+
+## 1. Clarify and scope
+
+<!--
+  Four to eight questions. Each one either removes work or changes the design; if
+  the answer changes nothing, cut the question. Give the answer you will design
+  against so the rest of the topic has fixed numbers to use.
+-->
+
+- **Question?** Assumed answer, and what it rules out.
+
+## 2. Requirements
+
+**Functional**
+
+- ...
+
+**Non-functional** (the ones with numbers: latency target, QPS, corpus size, budget)
+
+- ...
+
+**Out of scope**
+
+- ...
+
+## 3. High-level design
+
+The offline path and the online path, then one mermaid diagram of the whole system.
+
+```mermaid
+flowchart LR
+  A[Request] --> B[Component]
+  B --> C[(Store)]
+```
+
+<!-- Mermaid line breaks are <br/>, never \n. Quote any label containing a comma. -->
+
+## 4. Deep dives
+
+<!--
+  Three to five subsections, one per component that carries real signal. This is
+  where the topic earns its length. Each subsection: what the component does, the
+  one formula or number that governs it, the options, and what each option costs.
+-->
+
+### 4.1 Component
+
+The governing arithmetic, with units:
+
+$$
+\text{cost} = \text{something} \times \text{something}
+$$
+
+<!--
+  Math renders through GitHub's KaTeX: use \ast not *, \lt not <, \text{} not
+  \operatorname{}, and escape a literal dollar amount as \$5,000 so it does not
+  pair with a real inline-math delimiter.
+-->
+
+| Option | When to use | What it costs |
+|---|---|---|
+| | | |
+
+## 5. Bottlenecks and scaling
+
+What breaks first as load grows, and the order in which you would fix it. Give the
+number at which each becomes the bottleneck.
+
+## 6. Failure modes, safety, and eval
+
+How it fails, how you would know, and what you measure to prove it works. Prefer
+metrics that can be computed online without labels.
+
+## 7. Likely follow-ups
+
+- **"..."** The short answer, with the tradeoff named.
+
+## Seen in production
+
+<!--
+  First-party engineering writeups only, and each bullet in exactly this shape, or
+  tools/build.mjs cannot parse it into the case indexes:
+
+  - **Company** [Title of the writeup](https://url) - what it illustrates.
+
+  After adding one, run `node tools/build.mjs`.
+-->
+
+- **Company** [Title](https://example.com) - what this one illustrates.
+
+## Trace the architectures
+
+<!--
+  Link the relevant model as a live graph rather than a picture, if one applies.
+  The set lives at https://github.com/neurarch-ai/awesome-llm-model-zoo
+-->
+
+## Related deep-dive drills
+
+Rapid-fire questions that probe what is underneath this topic, from
+[deep-dives.md](../deep-dives.md):
+
+- [Section name](../deep-dives.md#section-anchor)

--- a/tools/README.md
+++ b/tools/README.md
@@ -24,6 +24,22 @@ This rebuilds four files from `topics/` plus the sources in this folder:
 3. Refresh `tools/comparisons/NN.md` so the diagram/table/quadrant include the new company.
 4. Run `node tools/build.mjs`.
 
+## The site
+
+`build-site.mjs` stages the repo into `.site/` (gitignored) and writes the mkdocs
+config that renders it at
+<https://neurarch-ai.github.io/awesome-llm-system-design/>. Nothing in it is a second
+copy of the content: page titles are read from each file's H1, and the book's chapter
+order and grouping are read from the tables in `book/README.md` and
+`book-zh/README.md`, so a new chapter reaches the sidebar by being listed there.
+
+```
+pip install -r tools/requirements-site.txt
+node tools/build-site.mjs && mkdocs serve -f .site/mkdocs.yml
+```
+
+Deployed by `.github/workflows/site.yml` on every push to `main`.
+
 ## Conventions
 
 No em or en dashes anywhere. Math is GitHub-flavored LaTeX; do not use `\operatorname` (GitHub's KaTeX rejects it, use `\text{...}`) and never put `#` inside math (use `n_{\text{bins}}` style). Every Mermaid code fence must be closed; `quadrantChart` point labels with spaces must be quoted.

--- a/tools/build-site.mjs
+++ b/tools/build-site.mjs
@@ -265,7 +265,14 @@ theme:
         name: Switch to light mode
 
 plugins:
-  - search
+  # jieba (see tools/requirements-site.txt) segments the Chinese edition at index
+  # time and marks the word boundaries with a zero-width space, so the separator has
+  # to split on it. The trailing alternative splits between two CJK characters as
+  # well, which is what makes a query someone actually types ("投机解码", no spaces)
+  # match text indexed as two words; without it the search box answers "no matching
+  # documents" for every multi-word Chinese query.
+  - search:
+      separator: '[\\s\\u200b\\-,:!=\\[\\]()"/]+|(?!\\b)(?=[A-Z][a-z])|\\.(?!\\d)|&[lg]t;|(?<=[\\u4e00-\\u9fff])(?=[\\u4e00-\\u9fff])'
 
 markdown_extensions:
   - abbr

--- a/tools/build-site.mjs
+++ b/tools/build-site.mjs
@@ -1,0 +1,347 @@
+#!/usr/bin/env node
+// Stage the repo as a browsable MkDocs site under .site/ (gitignored).
+//
+// Why this exists: the repo is ~490 markdown files and 75k lines. On GitHub that
+// is a file listing, so a reader has to already know which file they want. The
+// site gives it a sidebar, a search box, and stable URLs, from exactly the same
+// markdown, with no second copy of the content to keep in sync.
+//
+// What it does:
+//   1. Mirrors the repo into .site/content/ (skipping .git, .github, .site).
+//   2. Derives the whole nav from the files themselves: page titles are each
+//      file's H1, and the book chapter order and grouping are read out of
+//      book/README.md (and book-zh/README.md) rather than restated here, so a new
+//      chapter appears in the sidebar as soon as it is listed in that README.
+//   3. Writes .site/mkdocs.yml.
+//
+// Usage:
+//   node tools/build-site.mjs           # stage + write config
+//   mkdocs serve -f .site/mkdocs.yml    # local preview at 127.0.0.1:8000
+//   mkdocs build -f .site/mkdocs.yml    # -> .site/out
+//
+// Dependencies for the mkdocs step only: pip install -r tools/requirements-site.txt
+
+import {
+  cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync,
+} from "node:fs";
+import { basename, join } from "node:path";
+
+const OUT = ".site";
+const CONTENT = join(OUT, "content");
+// tools/ is staged even though it is build machinery: every chapter summary links
+// its per-topic fragment under tools/comparisons and tools/teardowns directly, so
+// dropping it would break those links. The fragments stay out of the nav.
+const SKIP = new Set([".git", ".github", ".site", "node_modules", ".DS_Store"]);
+
+const SITE_NAME = "LLM System Design Interview";
+const SITE_URL = "https://neurarch-ai.github.io/awesome-llm-system-design/";
+const REPO_URL = "https://github.com/neurarch-ai/awesome-llm-system-design";
+
+// ---------------------------------------------------------------- staging
+
+function stage() {
+  rmSync(OUT, { recursive: true, force: true });
+  mkdirSync(CONTENT, { recursive: true });
+  for (const entry of readdirSync(".", { withFileTypes: true })) {
+    if (SKIP.has(entry.name)) continue;
+    cpSync(entry.name, join(CONTENT, entry.name), { recursive: true });
+  }
+  for (const f of walk(CONTENT)) resolveFolderLinks(f);
+}
+
+function walk(dir) {
+  const out = [];
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) out.push(...walk(p));
+    else if (e.name.endsWith(".md")) out.push(p);
+  }
+  return out;
+}
+
+// The book links a chapter as `[Agent Orchestration](agents/)`, which is right on
+// GitHub and wrong once pretty URLs move a section page down one path segment
+// (`.../reasoning-serving/09-summary/` + `../agents/` lands inside the chapter it
+// started in). Point those at the folder's README on the staged copy only, so the
+// markdown a reader sees on GitHub is untouched and both renderings resolve.
+function resolveFolderLinks(file) {
+  const dir = file.slice(0, file.lastIndexOf("/"));
+  const src = readFileSync(file, "utf8");
+  const out = src.replace(/\]\((?!https?:|#|\/)([^)\s]+\/)\)/g, (whole, target) =>
+    existsSync(join(dir, target, "README.md")) ? `](${target}README.md)` : whole,
+  );
+  if (out !== src) writeFileSync(file, out);
+}
+
+// ---------------------------------------------------------------- titles
+
+const titleCache = new Map();
+
+// The H1 of a page, with inline markdown stripped, used as its sidebar label.
+// Falls back to the filename so a page missing an H1 still gets a readable entry
+// rather than disappearing from the nav.
+function titleOf(path) {
+  if (titleCache.has(path)) return titleCache.get(path);
+  let title = null;
+  if (existsSync(path)) {
+    for (const line of readFileSync(path, "utf8").split("\n")) {
+      const m = line.match(/^#\s+(.+?)\s*$/);
+      if (m) { title = m[1]; break; }
+    }
+  }
+  if (!title) {
+    title = basename(path, ".md").replace(/^\d+-/, "").replace(/-/g, " ");
+    title = title.charAt(0).toUpperCase() + title.slice(1);
+  }
+  title = title
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1")
+    .trim();
+  titleCache.set(path, title);
+  return title;
+}
+
+const mdFiles = (dir) =>
+  readdirSync(dir).filter((f) => f.endsWith(".md")).sort();
+
+// Every page in a chapter folder, index first: mkdocs-material renders a section
+// whose first entry is its own index as a clickable section header.
+function chapterNav(dir) {
+  const files = mdFiles(dir);
+  const ordered = [
+    ...files.filter((f) => f === "README.md"),
+    ...files.filter((f) => f !== "README.md"),
+  ];
+  return ordered.map((f) => ({ title: titleOf(join(dir, f)), path: join(dir, f) }));
+}
+
+// ---------------------------------------------------------------- book nav
+
+// Read the chapter grouping straight out of the book's own README: each "### Group"
+// heading starts a group, and every link to a directory that exists under it is a
+// chapter, in the order the README lists them. Parsing the README instead of
+// hard-coding the order here means the sidebar cannot drift from the book's own
+// table of contents, and the Chinese edition needs no separate spec.
+function bookNav(root) {
+  const readme = join(root, "README.md");
+  const lines = readFileSync(readme, "utf8").split("\n");
+  const groups = [];
+  let current = null;
+  for (const line of lines) {
+    const h3 = line.match(/^###\s+(.+?)\s*$/);
+    if (h3) { current = { title: h3[1], chapters: [] }; groups.push(current); continue; }
+    for (const m of line.matchAll(/\]\(([^)#:]+?)\/\)/g)) {
+      const dir = join(root, m[1]);
+      if (!existsSync(dir) || !statSync(dir).isDirectory()) continue;
+      if (!current) continue;
+      if (current.chapters.some((c) => c.dir === dir)) continue;
+      current.chapters.push({ dir, title: titleOf(join(dir, "README.md")) });
+    }
+  }
+
+  const nav = [{ title: titleOf(readme), path: readme }];
+  // The standalone companion pages (the method, reading paths, numbers, mock
+  // interview) sit next to the chapter folders and are not in any group.
+  for (const f of mdFiles(root)) {
+    if (f === "README.md") continue;
+    nav.push({ title: titleOf(join(root, f)), path: join(root, f) });
+  }
+  for (const g of groups.filter((g) => g.chapters.length)) {
+    nav.push({
+      title: g.title,
+      children: g.chapters.map((c) => ({ title: c.title, children: chapterNav(c.dir) })),
+    });
+  }
+  return nav;
+}
+
+function topicsNav() {
+  const files = mdFiles("topics");
+  return [
+    { title: "All topics", path: "topics/README.md" },
+    ...files
+      .filter((f) => f !== "README.md")
+      .map((f) => ({ title: titleOf(join("topics", f)), path: join("topics", f) })),
+  ];
+}
+
+// ---------------------------------------------------------------- yaml
+
+const q = (s) => `"${String(s).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+
+function navYaml(items, depth) {
+  const pad = "  ".repeat(depth);
+  return items
+    .map((it) =>
+      it.children
+        ? `${pad}- ${q(it.title)}:\n${navYaml(it.children, depth + 1)}`
+        : `${pad}- ${q(it.title)}: ${it.path}`,
+    )
+    .join("\n");
+}
+
+const optional = (title, path) => (existsSync(path) ? [{ title, path }] : []);
+
+function buildNav() {
+  const nav = [
+    { title: "Home", path: "README.md" },
+    { title: "Topics", children: topicsNav() },
+    { title: "The book", children: bookNav("book") },
+    ...optional("Papers", "papers.md").map((p) => ({ ...p, title: "Papers" })),
+    {
+      title: "Case studies",
+      children: [
+        { title: "By topic", path: "CASE-STUDIES.md" },
+        { title: "Teardowns", path: "CASE-TEARDOWNS.md" },
+        { title: "By company", path: "CASE-STUDIES-BY-COMPANY.md" },
+        { title: "By industry", path: "CASE-STUDIES-BY-INDUSTRY.md" },
+      ],
+    },
+    {
+      title: "Practice",
+      children: [
+        { title: "Question bank", path: "questions.md" },
+        { title: "Deep dives", path: "deep-dives.md" },
+        { title: "The answer framework", path: "framework/answer-framework.md" },
+      ],
+    },
+    ...(existsSync("book-zh") ? [{ title: "中文版", children: bookNav("book-zh") }] : []),
+    {
+      title: "Contributing",
+      children: [
+        { title: "How to contribute", path: "CONTRIBUTING.md" },
+        ...optional("Templates", "template/README.md"),
+      ],
+    },
+  ];
+  return nav;
+}
+
+// ---------------------------------------------------------------- config
+
+function mkdocsYml(nav) {
+  return `# Generated by tools/build-site.mjs. Do not edit; edit the generator.
+site_name: ${q(SITE_NAME)}
+site_url: ${SITE_URL}
+site_description: ${q("Interview-ready walkthroughs of production LLM systems: RAG, KV cache, serving, agents, evals, guardrails.")}
+repo_url: ${REPO_URL}
+repo_name: neurarch-ai/awesome-llm-system-design
+edit_uri: edit/main/
+docs_dir: content
+site_dir: out
+
+theme:
+  name: material
+  language: en
+  icon:
+    repo: fontawesome/brands/github
+  features:
+    - navigation.tabs
+    - navigation.indexes
+    - navigation.top
+    - navigation.tracking
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.action.edit
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: deep purple
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep purple
+      accent: deep purple
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+plugins:
+  - search
+
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+      toc_depth: 3
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  # The book writes math as GitHub-flavoured KaTeX ($...$ and $$...$$), so the site
+  # renders it with KaTeX too rather than MathJax: same engine, same output.
+  - pymdownx.arithmatex:
+      generic: true
+  # This exact custom fence is also what makes mkdocs-material load and theme
+  # mermaid itself, so the book's diagrams need no extra script.
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+
+# Many pages link to files that are not nav entries (assets, scripts, the license),
+# which is expected here rather than an error.
+validation:
+  nav:
+    omitted_files: info
+    not_found: warn
+  links:
+    absolute_links: info
+    unrecognized_links: info
+
+extra_javascript:
+  - javascripts/katex.js
+  - https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js
+  - https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js
+
+extra_css:
+  - https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css
+
+nav:
+${navYaml(nav, 1)}
+`;
+}
+
+const KATEX_JS = `// Render arithmatex's generic output with KaTeX, re-running on instant navigation.
+document$.subscribe(() => {
+  renderMathInElement(document.body, {
+    delimiters: [
+      { left: "$$", right: "$$", display: true },
+      { left: "$", right: "$", display: false },
+      { left: "\\\\(", right: "\\\\)", display: false },
+      { left: "\\\\[", right: "\\\\]", display: true },
+    ],
+    throwOnError: false,
+  });
+});
+`;
+
+// ---------------------------------------------------------------- main
+
+const nav = buildNav();
+stage();
+mkdirSync(join(CONTENT, "javascripts"), { recursive: true });
+writeFileSync(join(CONTENT, "javascripts", "katex.js"), KATEX_JS);
+writeFileSync(join(OUT, "mkdocs.yml"), mkdocsYml(nav));
+
+const count = (items) =>
+  items.reduce((n, it) => n + (it.children ? count(it.children) : 1), 0);
+console.log(`site staged: ${count(nav)} pages in nav, config at ${join(OUT, "mkdocs.yml")}`);

--- a/tools/check-links.mjs
+++ b/tools/check-links.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// On-demand external-link checker for book/**/*.md and book-zh/**/*.md.
+// On-demand external-link checker for book/**/*.md, book-zh/**/*.md and papers.md.
 // Fetches every http(s) URL and classifies it:
 //   OK        2xx / 3xx
 //   BLOCKED   401/403/405/406/429 (bot-block or auth wall; the page almost certainly exists)
@@ -14,6 +14,11 @@ import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
 
 const ROOTS = ["book", "book-zh"].filter((d) => existsSync(d));
+// papers.md is checked too: it is 130+ external links and nothing else in it, so
+// link rot there is the whole failure mode. The case-study indexes are deliberately
+// left out; they point at hundreds of company blogs that get reorganized constantly,
+// and one of those going 404 should not turn this job red every month.
+const FILES = ["papers.md"].filter((f) => existsSync(f));
 const CONCURRENCY = 12;
 const TIMEOUT_MS = 20000;
 const UA = "Mozilla/5.0 (compatible; neurarch-linkcheck/1.0)";
@@ -30,7 +35,7 @@ function walk(dir) {
 
 // url -> Set of files that reference it
 const refs = new Map();
-for (const f of ROOTS.flatMap(walk)) {
+for (const f of [...ROOTS.flatMap(walk), ...FILES]) {
   const t = readFileSync(f, "utf8");
   for (const m of t.matchAll(/\]\((https?:\/\/[^)\s]+)\)/g)) {
     const u = m[1];
@@ -39,7 +44,8 @@ for (const f of ROOTS.flatMap(walk)) {
   }
 }
 const urls = [...refs.keys()];
-console.log(`Checking ${urls.length} unique external URLs from ${ROOT}/ ...\n`);
+const SOURCES = [...ROOTS.map((r) => `${r}/`), ...FILES].join(", ");
+console.log(`Checking ${urls.length} unique external URLs from ${SOURCES} ...\n`);
 
 const BLOCKED = new Set([401, 403, 405, 406, 429]);
 
@@ -79,7 +85,7 @@ console.log(`OK: ${results.length - dead.length - blocked.length}   BLOCKED (lik
 if (dead.length) {
   console.log("DEAD links (fix these):");
   for (const d of dead.sort((a, b) => String(a.status).localeCompare(String(b.status)))) {
-    const where = [...refs.get(d.u)].map((f) => f.replace(ROOT + "/", "")).join(", ");
+    const where = [...refs.get(d.u)].join(", ");
     console.log(`  [${d.status}] ${d.u}\n        in: ${where}`);
   }
   process.exit(1);

--- a/tools/requirements-site.txt
+++ b/tools/requirements-site.txt
@@ -1,0 +1,8 @@
+# Needed only to render the site. node tools/build-site.mjs writes .site/mkdocs.yml
+# and stages the markdown; mkdocs turns it into HTML.
+#   pip install -r tools/requirements-site.txt
+#   node tools/build-site.mjs && mkdocs serve -f .site/mkdocs.yml
+mkdocs-material>=9.5,<10
+# Chinese word segmentation for book-zh/. The search plugin uses it when present,
+# and without it a search for a Chinese term matches nothing on the whole edition.
+jieba>=0.42

--- a/topics/15-continued-pretraining-and-long-context.md
+++ b/topics/15-continued-pretraining-and-long-context.md
@@ -580,7 +580,7 @@ Rapid-fire questions that probe the modeling and systems underneath this topic, 
 
 - [Training, fine-tuning, and overfitting](../deep-dives.md#training-fine-tuning-and-overfitting)
 - [Scaling: rooflines, parallelism, and the arithmetic of large models](../deep-dives.md#scaling-rooflines-parallelism-and-the-arithmetic-of-large-models)
-- [Normalization and attention variants](../deep-dives.md#normalization-and-attention-variants)
+- [Attention variants and positional encoding](../deep-dives.md#attention-variants-and-positional-encoding)
 - [Commonly asked, commonly missed](../deep-dives.md#commonly-asked-commonly-missed)
 
 ## Seen in production

--- a/topics/README.md
+++ b/topics/README.md
@@ -15,10 +15,13 @@ shape, mirroring the [answer framework](../framework/answer-framework.md):
 
 ## Topics by pipeline stage
 
-All fifteen topics are written. They are grouped by where they sit in a production LLM
+All eighteen topics are written. They are grouped by where they sit in a production LLM
 system, in narrative order from building the model to watching it in production. To
 navigate by use case instead, start from the
 [question bank](../questions.md).
+
+Each topic's reading list is in [papers.md](../papers.md), which caps every topic at
+eight papers.
 
 **Building and adapting the model**
 - [13 - The LLM training lifecycle](13-llm-lifecycle.md)


### PR DESCRIPTION
This started as a comparison against [diff-usion/Awesome-Diffusion-Models](https://github.com/diff-usion/Awesome-Diffusion-Models) (12.4k stars, no real commit since 2023-11) and [BradyFU/Awesome-Multimodal-Large-Language-Models](https://github.com/BradyFU/Awesome-Multimodal-Large-Language-Models) (18k stars, updated two days ago). Their content mostly does not overlap ours and their genre is not one to copy: a link list needs constant hand maintenance, and a wall of links carries none of this repo's hook. What is worth copying is the mechanisms that make a large list readable, plus the topics that comparing against them exposed as missing here.

## 1. A site (`tools/build-site.mjs`, `.github/workflows/site.yml`)

490 markdown files and 75k lines are a file listing on GitHub: you have to already know which file you want. This publishes the same markdown with a sidebar and a search box, keeping no second copy of the content:

- Chapter order and grouping are read from the tables in `book/README.md` and `book-zh/README.md`, page titles from each file's H1, so a new chapter reaches the sidebar by being listed there and nowhere else.
- Folder links (`](agents/)`) are pointed at the folder README **on the staged copy only**, because pretty URLs push a section page down one path segment and `../agents/` from `09-summary/` would land back inside its own chapter.
- English and Chinese in one site, KaTeX and mermaid working, Chinese search via jieba.

**One-time setup needed after merge: Settings > Pages > Source = GitHub Actions.**

Two bugs here were findable only by driving the site in a browser:

- **Chinese search returned nothing.** jieba was installed, the build had zero warnings, the log even printed that jieba had loaded. The index carried zero-width word boundaries; the `separator` was `[\s\-]+`, which splits on neither those nor a CJK boundary, so a whole-word query could never match a segmented index. Searching 投机解码 now returns 152 documents with the two sections about it on top.
- **About 1,750 lists across the repo rendered as run-on paragraphs.** CommonMark lets a list interrupt a paragraph and Python-Markdown does not, so `**Tricks and gotchas**` followed straight by bullets is a list on GitHub and one paragraph on the site. Fixed on the staged copy (873 blank lines inserted), only where the list actually interrupts a paragraph.

## 2. `papers.md` and `datasets.md`

Per topic, eight entries maximum, each with one line on what it changes for the reader. The cap is the editorial position: a list of everything is an index of a field, not a study plan.

- **papers.md** carries the 128 papers the walkthroughs already cite plus the canon each topic assumes. All 154 arXiv ids were verified against arXiv itself.
- **datasets.md** (borrowed from BradyFU's separate Awesome Datasets section) is organized by pipeline stage: pretraining corpora, instruction and chat data, preference data, retrieval and embeddings, evaluation for knowledge, code and agents, multimodal, and generation. It opens with the four questions that actually get asked as follow-ups: licence, provenance, whether it is in your evaluation, and deduplication. "Where would the data come from" is the question candidates answer worst and the repo had no page for it.

Also fixes `tools/check-links.mjs`: the 2026-09-03 rename of `ROOT` to `ROOTS` missed two references, so the script threw `ReferenceError` at module scope. The last green run (09-01) was the old file and the next schedule is 10-01, so a monthly gate had been dead with nothing to show for it. Fixed and extended to cover both new pages.

## 3. `template/`

`topic.md` (the nine-section walkthrough) and `chapter/` (ten sections plus a capstone skeleton that already passes the runner), plus where a new file has to be registered before anything links to it, and four editorial rules that reviews here are actually about and that no CI check can test.

## 4. A README highlights block

BradyFU puts its lab's own benchmarks above the paper tables. The equivalent here is a table at the top naming what ships alongside the text (Model Zoo, papers.md, datasets.md, the case studies, the question bank) with one line each on what to use it for. It also corrected a stale count: the Model Zoo has 92 architectures, the README still said 87.

## 5. Topics 16, 17 and 18 join the case taxonomy

`collect()` scanned every numbered file under `topics/` while `csOrder` listed only fifteen, so `CASE-STUDIES.md` said 244 cases and regenerating the two pivots produced 276. The extra rows were malformed too, because 16/17/18 never used the `- **Company** [Title](url): description *(tag)*` shape and packed three methods into one line, which is why `LLM.int8()`, `SmoothQuant` and `QuaRot` were appearing as companies. Their bullets are normalized, new comparison and teardown fragments are written, and the three topics join `csOrder` and `tdOrder`.

## 6. Two sections the multimodal chapter was missing

Checking our coverage against BradyFU's categories: multimodal hallucination is already covered (POPE and CHAIR in `book/multimodal/05-evaluation.md`), but two were genuinely absent.

- **Video: frames are the token budget.** Ten minutes at 1 fps, 336px, patch 14 is 345,600 tokens; the same clip at 0.5 fps with a 2x2 merge is 43,200, and neither number involved changing models. Levers in order, the subtitle-instead-of-frames option candidates miss, the benchmark trap (a question answerable from one sampled frame reports that your frame budget is free), and why long video is a prefill problem.
- **Preference alignment for a VLM.** Three shapes of visually grounded preference data by cost, and the general form: a preference signal is only as grounded as what the annotator, or the generator, was forced to look at.

Added to `topics/09`, `book/multimodal/` and the `book-zh/` mirrors.

## 7. Topic 19 and a new chapter: image and video generation serving

"diffusion" appeared seven times in the whole repo, all in `world-models` and `deep-dives`. This is the one genuine content borrow from the diffusion list, and a real 2026 interview area.

The chapter exists because its cost model is not the KV cache: no autoregressive loop, no KV cache, no per-token bill, just $N_{FE} = S \cdot c$ with $c = 2$ under classifier-free guidance. The points an interviewer probes are all here: four variants are one batch and not four requests; 2048px is sixteen times the attention work of 1024px, not four; the memory spike is the VAE decode; compiled engines are the biggest inference-only win and cost cold start (about ten seconds eager against a minute compiled), which decides whether you can scale to zero; video is a queued job priced per second of output.

Writing the capstone caught me making the mistake the repo exists to prevent. The first queue simulation printed two identical rows while the prose claimed separate queues lowered p95. The rewritten version has three rows and a better conclusion: FIFO and drafts-first are identical, because a non-preemptive priority queue cannot preempt a render that is already running. Only giving each class its own capacity removes the blocking, which makes it a capacity decision rather than a scheduling one.

The Chinese edition is not behind: `book-zh/generation-serving/` mirrors all eleven files, with the capstone's code block copied byte for byte so the runner executes it from the translation as well.

## 8. A reference refresh for the world-models chapter

Checked against [knightnemo/Awesome-World-Models](https://github.com/knightnemo/Awesome-World-Models) (3.4k stars, created 2025-10, updated this month), which surfaced three real gaps: GAIA-2 (controllable and multi-view) where the chapter cited only GAIA-1, Cosmos-Drive-Dreams as the concrete instance of the data-engine claim, and a 2026 line of work on real-time interactive world models that the chapter's offline-engine framing predates. That last one earned a new section, because the interesting part for a serving answer is the memory structure (patch memory is the same problem a KV cache solves for text) rather than the generator. Further reading gained Genie Envisioner, iVideoGPT, WorldLens, SimWorld, a survey, and the list itself. 13 arXiv ids verified by title. The Chinese edition is updated in the same commit.

## Verification

- `node tools/validate-book.mjs`: 450 files clean
- `python3 tools/run-capstones.py`: all 40 capstone runnables passed
- `node tools/build.mjs`: hash-stable across two runs, no unmapped companies; 299 systems, 19 categories, 151 teardowns, and all four generated files agreeing on one set for the first time
- Link checks: 372 URLs from `book/` and `papers.md` (0 dead), 42 in `datasets.md` (0 dead), 61 in the new chapter, topic and fragments (0 dead)
- `mkdocs build`: 0 warnings, and English pages, Chinese pages, math, mermaid, both search paths and the list rendering fix were checked in a real browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gbAWGukEBsPE7wAwp36gA
