### PR TITLE
Fix the site workflow: pip cache fails the job without an explicit dependency path

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -32,7 +32,11 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          # `cache: pip` looks for **/requirements.txt or **/pyproject.toml and fails
+          # the job when it finds neither. Ours is tools/requirements-site.txt, so the
+          # path has to be named explicitly.
           cache: pip
+          cache-dependency-path: tools/requirements-site.txt
       - name: Install mkdocs
         run: pip install -r tools/requirements-site.txt
       - name: Stage content and write the mkdocs config

--- a/.github/workflows/validate-book.yml
+++ b/.github/workflows/validate-book.yml
@@ -1,6 +1,11 @@
 name: Validate book
 
 on:
+  # Manual trigger, so a green can be produced on demand. The path filters below are
+  # correct and do skip this workflow on a change that touches neither book tree,
+  # which is what happened on the merged part of PR #7; without a manual trigger
+  # there was no way to tell that skip apart from a failure that never reported.
+  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ numbers change. More on why that matters [below](#about-the-diagrams).
 
 > **Want a sidebar and a search box?** The same material is published as a site at
 > **[neurarch-ai.github.io/awesome-llm-system-design](https://neurarch-ai.github.io/awesome-llm-system-design/)**,
-> generated from these exact files. Searching there covers all 490 pages at once,
-> including the Chinese edition, which is the fastest way to find the one paragraph
-> that answers a question you are stuck on.
+> generated from these exact files. Searching there covers every page of both
+> editions at once, which is the fastest way to find the one paragraph that answers a
+> question you are stuck on.
 
 ---
 


### PR DESCRIPTION
The site workflow merged with #7 and failed on its first real run, in 9 seconds:

```
##[error]No file in /home/runner/work/awesome-llm-system-design/awesome-llm-system-design
matched to [**/requirements.txt or **/pyproject.toml], make sure you have checked out
the target repository
```

`actions/setup-python` with `cache: pip` looks for those two globs and **fails the job** when it finds neither. Our dependency file is `tools/requirements-site.txt`, which matches neither, so `cache-dependency-path` has to name it. That is the whole fix.

This is the lesson this repo already writes down, arriving on my own work: the workflow's YAML was validated and the build was run locally, but the workflow itself was never executed, so its first run was its first failure.

Also drops the stale "490 pages" from the README. That number was already moving when I wrote it (530 markdown files now), so it is replaced with a phrasing that does not carry one.

## Still needed after this merges

The `deploy` job will still fail until GitHub Pages is enabled for the repository: **Settings > Pages > Source = GitHub Actions**. `GET /repos/neurarch-ai/awesome-llm-system-design/pages` currently returns 404, which is what "not enabled" looks like from the API. Only a repository admin can do that, and it is the one step of #7 that could not be done in a pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016gbAWGukEBsPE7wAwp36gA